### PR TITLE
fix(web): remove PKR from multi-currency feature description

### DIFF
--- a/src/pages/home/_component/features-section.tsx
+++ b/src/pages/home/_component/features-section.tsx
@@ -27,7 +27,7 @@ const features = [
     icon: Globe,
     title: "Multi-currency, everywhere.",
     description:
-      "Track in USD, EUR, PKR, AED, or any other currency. Expenses are stored with the currency you set — no manual conversion, no extra steps.",
+      "Track in USD, EUR, GBP, AED, or any other currency. Expenses are stored with the currency you set — no manual conversion, no extra steps.",
   },
   {
     number: "05",


### PR DESCRIPTION
## Summary

- Replace PKR with GBP in the multi-currency feature description on the home page, aligning with the USD-first currency standard used across the platform.

## Test plan

- [ ] Home page features section shows USD, EUR, GBP, AED (not PKR)