### PR TITLE
feat(auth): Improve password visibility and OTP flows

### DIFF
--- a/src/components/otp-input.tsx
+++ b/src/components/otp-input.tsx
@@ -1,0 +1,90 @@
+import { useRef, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+
+interface OtpInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  length?: number;
+  disabled?: boolean;
+}
+
+const OtpInput = ({ value, onChange, length = 6, disabled = false }: OtpInputProps) => {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  // Ensure we have the right number of refs
+  useEffect(() => {
+    inputRefs.current = inputRefs.current.slice(0, length);
+  }, [length]);
+
+  const handleChange = (index: number, digit: string) => {
+    // Only accept digits
+    if (!/^\d*$/.test(digit)) return;
+
+    // Update the value
+    const newValue = value.split("");
+    newValue[index] = digit.slice(-1); // Take only last character if multiple were pasted
+    const combinedValue = newValue.join("");
+    onChange(combinedValue);
+
+    // Auto-focus to next field if digit entered
+    if (digit && index < length - 1) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Backspace") {
+      e.preventDefault();
+      const newValue = value.split("");
+      newValue[index] = "";
+      const combinedValue = newValue.join("");
+      onChange(combinedValue);
+
+      // Auto-focus to previous field
+      if (index > 0) {
+        inputRefs.current[index - 1]?.focus();
+      }
+    } else if (e.key === "ArrowLeft" && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    } else if (e.key === "ArrowRight" && index < length - 1) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pastedData = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, length);
+    onChange(pastedData);
+
+    // Focus last field if all digits pasted
+    if (pastedData.length === length) {
+      inputRefs.current[length - 1]?.focus();
+    } else if (pastedData.length > 0) {
+      inputRefs.current[pastedData.length]?.focus();
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      {Array.from({ length }).map((_, index) => (
+        <Input
+          key={index}
+          ref={(el) => {
+            inputRefs.current[index] = el;
+          }}
+          type="text"
+          inputMode="numeric"
+          maxLength={1}
+          value={value[index] || ""}
+          onChange={(e) => handleChange(index, e.target.value)}
+          onKeyDown={(e) => handleKeyDown(index, e)}
+          onPaste={handlePaste}
+          disabled={disabled}
+          className="h-12 w-12 text-center text-lg font-semibold"
+        />
+      ))}
+    </div>
+  );
+};
+
+export default OtpInput;

--- a/src/components/password-input.tsx
+++ b/src/components/password-input.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface PasswordInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  placeholder?: string;
+}
+
+const PasswordInput = ({ placeholder = "Enter password", ...props }: PasswordInputProps) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input
+        type={showPassword ? "text" : "password"}
+        placeholder={placeholder}
+        {...props}
+        className="pr-10"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="absolute right-0 top-1/2 -translate-y-1/2 hover:bg-transparent"
+        onClick={() => setShowPassword(!showPassword)}
+      >
+        {showPassword ? (
+          <EyeOff className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <Eye className="h-4 w-4 text-muted-foreground" />
+        )}
+      </Button>
+    </div>
+  );
+};
+
+export default PasswordInput;

--- a/src/features/auth/authAPI.ts
+++ b/src/features/auth/authAPI.ts
@@ -1,19 +1,58 @@
 import { apiClient } from "@/app/api-client";
+import type {
+  ForgotPasswordRequest,
+  ForgotPasswordResponse,
+  LoginResponse,
+  RegisterResponse,
+  ResendOtpRequest,
+  ResetPasswordRequest,
+  ResetPasswordResponse,
+  VerifyOtpRequest,
+  VerifyOtpResponse,
+} from "./authType";
 
 export const authApi = apiClient.injectEndpoints({
   endpoints: (builder) => ({
-    register: builder.mutation({
+    register: builder.mutation<RegisterResponse, Record<string, unknown>>({
       query: (credentials) => ({
         url: "/auth/register",
         method: "POST",
         body: credentials,
       }),
     }),
-    login: builder.mutation({
+    login: builder.mutation<LoginResponse, Record<string, unknown>>({
       query: (credentials) => ({
         url: "/auth/login",
         method: "POST",
         body: credentials,
+      }),
+    }),
+    verifyOtp: builder.mutation<VerifyOtpResponse, VerifyOtpRequest>({
+      query: (body) => ({
+        url: "/auth/verify-otp",
+        method: "POST",
+        body,
+      }),
+    }),
+    resendOtp: builder.mutation<{ message: string }, ResendOtpRequest>({
+      query: (body) => ({
+        url: "/auth/resend-otp",
+        method: "POST",
+        body,
+      }),
+    }),
+    forgotPassword: builder.mutation<ForgotPasswordResponse, ForgotPasswordRequest>({
+      query: (body) => ({
+        url: "/auth/forgot-password",
+        method: "POST",
+        body,
+      }),
+    }),
+    resetPassword: builder.mutation<ResetPasswordResponse, ResetPasswordRequest>({
+      query: (body) => ({
+        url: "/auth/reset-password",
+        method: "POST",
+        body,
       }),
     }),
 
@@ -36,6 +75,10 @@ export const authApi = apiClient.injectEndpoints({
 export const {
   useLoginMutation,
   useRegisterMutation,
+  useVerifyOtpMutation,
+  useResendOtpMutation,
+  useForgotPasswordMutation,
+  useResetPasswordMutation,
   useRefreshMutation,
   useLogoutMutation,
 } = authApi;

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -8,10 +8,11 @@ interface AuthState {
 }
 
 interface User {
-  id: number;
+  id: string;
   name: string;
   email: string;
-  profilePicture: string;
+  profilePicture: string | null;
+  isVerified?: boolean;
 }
 
 interface ReportSetting {

--- a/src/features/auth/authType.ts
+++ b/src/features/auth/authType.ts
@@ -1,0 +1,72 @@
+export interface AuthUser {
+	id: string;
+	name: string;
+	email: string;
+	profilePicture?: string | null;
+	isVerified?: boolean;
+}
+
+export interface AuthReportSetting {
+	userId: string;
+	frequency?: string;
+	isEnabled: boolean;
+}
+
+export interface RegisterResponse {
+	message: string;
+	data?: {
+		user: AuthUser;
+		verificationRequired: boolean;
+	};
+}
+
+export interface LoginResponse {
+	message?: string;
+	user: AuthUser;
+	accessToken: string;
+	expiresAt: number;
+	reportSetting: AuthReportSetting | null;
+}
+
+export interface VerifyOtpRequest {
+	email: string;
+	otp: string;
+}
+
+export interface ResendOtpRequest {
+	email: string;
+}
+
+export interface VerifyOtpResponse {
+	message?: string;
+	user: AuthUser;
+	accessToken: string;
+	expiresAt: number;
+	reportSetting: AuthReportSetting | null;
+	verified: boolean;
+}
+
+export interface ForgotPasswordRequest {
+	email: string;
+}
+
+export interface ForgotPasswordResponse {
+	message: string;
+}
+
+export interface ResetPasswordRequest {
+	email: string;
+	otp: string;
+	password: string;
+}
+
+export interface ResetPasswordResponse {
+	message: string;
+}
+
+export interface ErrorResponse {
+	data?: {
+		message?: string;
+		errorCode?: string;
+	};
+}

--- a/src/pages/auth/_component/forgot-password-form.tsx
+++ b/src/pages/auth/_component/forgot-password-form.tsx
@@ -1,0 +1,84 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useNavigate, createSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { Loader } from "lucide-react";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { AUTH_ROUTES } from "@/routes/common/routePath";
+import { useForgotPasswordMutation } from "@/features/auth/authAPI";
+
+const schema = z.object({
+  email: z.string().email("Invalid email address"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const ForgotPasswordForm = () => {
+  const navigate = useNavigate();
+  const [forgotPassword, { isLoading }] = useForgotPasswordMutation();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = (values: FormValues) => {
+    forgotPassword(values)
+      .unwrap()
+      .then(() => {
+        toast.success("Reset code sent to your email");
+        navigate({
+          pathname: AUTH_ROUTES.VERIFY_RESET_OTP,
+          search: createSearchParams({ email: values.email }).toString(),
+        });
+      })
+      .catch((error) => {
+        toast.error(error.data?.message || "Failed to send reset code");
+      });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-2xl font-bold">Forgot password</h1>
+          <p className="text-balance text-sm text-muted-foreground">
+            Enter your email and we’ll send a reset code.
+          </p>
+        </div>
+
+        <div className="grid gap-6">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input placeholder="Your email address" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button disabled={isLoading} type="submit" className="w-full">
+            {isLoading && <Loader className="h-4 w-4 animate-spin" />}
+            Send reset code
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default ForgotPasswordForm;

--- a/src/pages/auth/_component/reset-password-form.tsx
+++ b/src/pages/auth/_component/reset-password-form.tsx
@@ -1,0 +1,125 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { AUTH_ROUTES } from "@/routes/common/routePath";
+import { useResetPasswordMutation } from "@/features/auth/authAPI";
+
+const schema = z.object({
+  email: z.string().email("Invalid email address"),
+  otp: z.string().regex(/^\d{6}$/, "Enter the 6-digit reset code"),
+  password: z.string().min(6, "Password must be at least 6 characters"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const ResetPasswordForm = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const emailFromQuery = searchParams.get("email") ?? "";
+  const [resetPassword, { isLoading }] = useResetPasswordMutation();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: emailFromQuery,
+      otp: "",
+      password: "",
+    },
+  });
+
+  useEffect(() => {
+    if (emailFromQuery) {
+      form.setValue("email", emailFromQuery);
+    }
+  }, [emailFromQuery, form]);
+
+  const onSubmit = (values: FormValues) => {
+    resetPassword(values)
+      .unwrap()
+      .then((data) => {
+        toast.success(data.message || "Password reset successfully");
+        navigate(AUTH_ROUTES.SIGN_IN);
+      })
+      .catch((error) => {
+        toast.error(error.data?.message || "Failed to reset password");
+      });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-2xl font-bold">Reset password</h1>
+          <p className="text-balance text-sm text-muted-foreground">
+            Enter the code from your email and set a new password.
+          </p>
+        </div>
+
+        <div className="grid gap-6">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input placeholder="Your email address" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="otp"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Reset code</FormLabel>
+                <FormControl>
+                  <Input inputMode="numeric" maxLength={6} placeholder="123456" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New password</FormLabel>
+                <FormControl>
+                  <Input type="password" placeholder="Enter new password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button disabled={isLoading} type="submit" className="w-full">
+            {isLoading && <Loader className="h-4 w-4 animate-spin" />}
+            Reset password
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default ResetPasswordForm;

--- a/src/pages/auth/_component/set-new-password-form.tsx
+++ b/src/pages/auth/_component/set-new-password-form.tsx
@@ -1,0 +1,118 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import PasswordInput from "@/components/password-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { AUTH_ROUTES } from "@/routes/common/routePath";
+import { useResetPasswordMutation } from "@/features/auth/authAPI";
+
+const schema = z.object({
+  password: z.string().min(6, "Password must be at least 6 characters"),
+  confirmPassword: z.string().min(6, "Password must be at least 6 characters"),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "Passwords don't match",
+  path: ["confirmPassword"],
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const SetNewPasswordForm = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const emailFromQuery = searchParams.get("email") ?? "";
+  const otpFromQuery = searchParams.get("otp") ?? "";
+  const [resetPassword, { isLoading }] = useResetPasswordMutation();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!emailFromQuery || !otpFromQuery) {
+      toast.error("Invalid session. Please start over.");
+      navigate(AUTH_ROUTES.FORGOT_PASSWORD);
+    }
+  }, [emailFromQuery, otpFromQuery, navigate]);
+
+  const onSubmit = (values: FormValues) => {
+    resetPassword({
+      email: emailFromQuery,
+      otp: otpFromQuery,
+      password: values.password,
+    })
+      .unwrap()
+      .then(() => {
+        toast.success("Password reset successfully");
+        navigate(AUTH_ROUTES.SIGN_IN);
+      })
+      .catch((error) => {
+        toast.error(error.data?.message || "Failed to reset password");
+      });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-2xl font-bold">Create new password</h1>
+          <p className="text-balance text-sm text-muted-foreground">
+            Enter your new password below
+          </p>
+        </div>
+
+        <div className="grid gap-6">
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New password</FormLabel>
+                <FormControl>
+                  <PasswordInput placeholder="Min. 6 characters" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm password</FormLabel>
+                <FormControl>
+                  <PasswordInput placeholder="Re-enter your password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button disabled={isLoading} type="submit" className="w-full">
+            {isLoading && <Loader className="h-4 w-4 animate-spin" />}
+            Reset password
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default SetNewPasswordForm;

--- a/src/pages/auth/_component/signin-form.tsx
+++ b/src/pages/auth/_component/signin-form.tsx
@@ -1,7 +1,8 @@
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Link, useNavigate } from "react-router-dom";
+import PasswordInput from "@/components/password-input";
+import { Link, createSearchParams, useNavigate } from "react-router-dom";
 import { AUTH_ROUTES, PROTECTED_ROUTES } from "@/routes/common/routePath";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
@@ -19,6 +20,7 @@ import { Loader } from "lucide-react";
 import { useLoginMutation } from "@/features/auth/authAPI";
 import { useAppDispatch } from "@/app/hook";
 import { setCredentials } from "@/features/auth/authSlice";
+import type { ErrorResponse } from "@/features/auth/authType";
 
 const schema = z.object({
   email: z.string().email("Invalid email address"),
@@ -51,7 +53,17 @@ const SignInForm = ({
       })
       .catch((error) => {
         console.log(error);
-        toast.error(error.data?.message || "Failed to login");
+        const apiError = error as ErrorResponse;
+        if (apiError.data?.errorCode === "AUTH_EMAIL_NOT_VERIFIED") {
+          navigate({
+            pathname: AUTH_ROUTES.VERIFY_OTP,
+            search: createSearchParams({ email: values.email }).toString(),
+          });
+          toast.error(apiError.data?.message || "Please verify your email first");
+          return;
+        }
+
+        toast.error(apiError.data?.message || "Failed to login");
       });
   };
 
@@ -92,7 +104,7 @@ const SignInForm = ({
                 <FormItem>
                   <FormLabel className="!font-normal">Password</FormLabel>
                   <FormControl>
-                    <Input placeholder="Enter your password" type="password" {...field} />
+                    <PasswordInput placeholder="Enter your password" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -104,14 +116,22 @@ const SignInForm = ({
             Login
           </Button>
         </div>
-        <div className="text-center text-sm">
-          Don&apos;t have an account?{" "}
+        <div className="flex items-center justify-between text-sm">
           <Link
-            to={AUTH_ROUTES.SIGN_UP}
+            to={AUTH_ROUTES.FORGOT_PASSWORD}
             className="underline underline-offset-4"
           >
-            Sign up
+            Forgot password?
           </Link>
+          <span>
+            Don&apos;t have an account?{" "}
+            <Link
+              to={AUTH_ROUTES.SIGN_UP}
+              className="underline underline-offset-4"
+            >
+              Sign up
+            </Link>
+          </span>
         </div>
       </form>
     </Form>

--- a/src/pages/auth/_component/signup-form.tsx
+++ b/src/pages/auth/_component/signup-form.tsx
@@ -4,7 +4,8 @@ import { Loader } from "lucide-react";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Link, useNavigate } from "react-router-dom";
+import PasswordInput from "@/components/password-input";
+import { Link, createSearchParams, useNavigate } from "react-router-dom";
 import { AUTH_ROUTES } from "@/routes/common/routePath";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -16,6 +17,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { useRegisterMutation } from "@/features/auth/authAPI";
+import type { ErrorResponse } from "@/features/auth/authType";
 
 const schema = z.object({
   name: z.string().min(2, "Name must be at least 2 characters"),
@@ -38,12 +40,24 @@ const SignUpForm = () => {
       .unwrap()
       .then(() => {
         form.reset();
-        toast.success("Sign up successful");
-        navigate(AUTH_ROUTES.SIGN_IN);
+        toast.success("Verification code sent to your email");
+        navigate({
+          pathname: AUTH_ROUTES.VERIFY_OTP,
+          search: createSearchParams({ email: values.email }).toString(),
+        });
       })
       .catch((error) => {
-        console.log(error);
-        toast.error(error.data?.message || "Failed to sign up");
+        const apiError = error as ErrorResponse;
+
+        if (apiError.data?.errorCode === "AUTH_EMAIL_ALREADY_EXISTS") {
+          toast.error(
+            apiError.data?.message ||
+              "An account with this email already exists. Please sign in instead."
+          );
+          return;
+        }
+
+        toast.error(apiError.data?.message || "Failed to sign up");
       });
   };
 
@@ -93,7 +107,7 @@ const SignUpForm = () => {
               <FormItem>
                 <FormLabel>Password</FormLabel>
                 <FormControl>
-                  <Input type="password" placeholder="Min. 6 characters" {...field} />
+                  <PasswordInput placeholder="Min. 6 characters" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/pages/auth/_component/verify-otp-form.tsx
+++ b/src/pages/auth/_component/verify-otp-form.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader, RefreshCcw } from "lucide-react";
+import { useSearchParams, Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import OtpInput from "@/components/otp-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { AUTH_ROUTES } from "@/routes/common/routePath";
+import {
+  useResendOtpMutation,
+  useVerifyOtpMutation,
+} from "@/features/auth/authAPI";
+
+import { useAppDispatch } from "@/app/hook";
+import { setCredentials } from "@/features/auth/authSlice";
+import { PROTECTED_ROUTES } from "@/routes/common/routePath";
+import type { ErrorResponse } from "@/features/auth/authType";
+
+const schema = z.object({
+  email: z.string().email("Invalid email address"),
+  otp: z.string().regex(/^\d{6}$/, "Enter the 6-digit code sent to your email"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const VerifyOtpForm = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const emailFromQuery = searchParams.get("email") ?? "";
+  const [verifyOtp, { isLoading }] = useVerifyOtpMutation();
+  const [resendOtp, { isLoading: isResending }] = useResendOtpMutation();
+  const [otpValue, setOtpValue] = useState("");
+  const dispatch = useAppDispatch();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: emailFromQuery,
+      otp: "",
+    },
+  });
+
+  useEffect(() => {
+    if (emailFromQuery) {
+      form.setValue("email", emailFromQuery);
+    }
+  }, [emailFromQuery, form]);
+
+  const onSubmit = (values: FormValues) => {
+    verifyOtp(values)
+      .unwrap()
+      .then((data) => {
+        toast.success("Email verified successfully!");
+        // Auto-login: Store credentials and redirect to dashboard
+        dispatch(setCredentials(data));
+        setTimeout(() => {
+          navigate(PROTECTED_ROUTES.OVERVIEW);
+        }, 1000);
+      })
+      .catch((error) => {
+        const apiError = error as ErrorResponse;
+        toast.error(apiError.data?.message || "Failed to verify code");
+      });
+  };
+
+  const handleResend = () => {
+    const email = form.getValues("email");
+    if (!email) {
+      toast.error("Enter your email first");
+      return;
+    }
+
+    resendOtp({ email })
+      .unwrap()
+      .then((data) => {
+        toast.success(data.message || "Verification code resent");
+      })
+      .catch((error) => {
+        toast.error(error.data?.message || "Failed to resend code");
+      });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-2xl font-bold">Verify your email</h1>
+          <p className="text-balance text-sm text-muted-foreground">
+            Enter the 6-digit code sent to your inbox to activate your account.
+          </p>
+        </div>
+
+        <div className="grid gap-6">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input placeholder="Your email address" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="otp"
+            render={() => (
+              <FormItem>
+                <FormLabel>Verification code</FormLabel>
+                <FormControl>
+                  <OtpInput
+                    value={otpValue}
+                    onChange={(value) => {
+                      setOtpValue(value);
+                      form.setValue("otp", value);
+                    }}
+                    disabled={isLoading}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button disabled={isLoading} type="submit" className="w-full">
+            {isLoading && <Loader className="h-4 w-4 animate-spin" />}
+            Verify email
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isResending}
+            onClick={handleResend}
+            className="w-full"
+          >
+            {isResending ? <Loader className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
+            Resend code
+          </Button>
+        </div>
+
+        <div className="text-center text-sm">
+          Already verified?{" "}
+          <Link to={AUTH_ROUTES.SIGN_IN} className="underline underline-offset-4">
+            Sign in
+          </Link>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default VerifyOtpForm;

--- a/src/pages/auth/_component/verify-reset-otp-form.tsx
+++ b/src/pages/auth/_component/verify-reset-otp-form.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader, RefreshCcw } from "lucide-react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import OtpInput from "@/components/otp-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { AUTH_ROUTES } from "@/routes/common/routePath";
+import {
+  useForgotPasswordMutation,
+} from "@/features/auth/authAPI";
+import { createSearchParams } from "react-router-dom";
+
+const schema = z.object({
+  email: z.string().email("Invalid email address"),
+  otp: z.string().regex(/^\d{6}$/, "Enter the 6-digit code sent to your email"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const VerifyResetOtpForm = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const emailFromQuery = searchParams.get("email") ?? "";
+  const [otpValue, setOtpValue] = useState("");
+  const [forgotPassword, { isLoading: isResending }] = useForgotPasswordMutation();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      email: emailFromQuery,
+      otp: "",
+    },
+  });
+
+  const onSubmit = (values: FormValues) => {
+    navigate({
+      pathname: AUTH_ROUTES.SET_NEW_PASSWORD,
+      search: createSearchParams({
+        email: values.email,
+        otp: values.otp,
+      }).toString(),
+    });
+  };
+
+  const handleResend = () => {
+    const email = form.getValues("email");
+    if (!email) {
+      toast.error("Enter your email first");
+      return;
+    }
+
+    forgotPassword({ email })
+      .unwrap()
+      .then(() => {
+        toast.success("Reset code resent to your email");
+      })
+      .catch((error) => {
+        toast.error(error.data?.message || "Failed to resend code");
+      });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-2xl font-bold">Verify reset code</h1>
+          <p className="text-balance text-sm text-muted-foreground">
+            Enter the 6-digit code sent to your email
+          </p>
+        </div>
+
+        <div className="grid gap-6">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input placeholder="Your email address" disabled {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="otp"
+            render={() => (
+              <FormItem>
+                <FormLabel>Reset code</FormLabel>
+                <FormControl>
+                  <OtpInput
+                    value={otpValue}
+                    onChange={(value) => {
+                      setOtpValue(value);
+                      form.setValue("otp", value);
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button disabled={otpValue.length !== 6} type="submit" className="w-full">
+            Continue
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isResending}
+            onClick={handleResend}
+            className="w-full"
+          >
+            {isResending ? <Loader className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
+            Resend code
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};
+
+export default VerifyResetOtpForm;

--- a/src/pages/auth/forgot-password.tsx
+++ b/src/pages/auth/forgot-password.tsx
@@ -1,0 +1,57 @@
+import Logo from "@/components/logo/logo";
+import { CheckCircle } from "lucide-react";
+import ForgotPasswordForm from "./_component/forgot-password-form";
+
+const ForgotPassword = () => {
+  const highlights = [
+    "Reset access with a secure email code",
+    "Codes expire automatically for safety",
+    "Restore your account without support",
+    "Keep your finance data protected",
+  ];
+
+  return (
+    <div className="min-h-svh grid lg:grid-cols-2">
+      <div className="flex flex-col gap-4 p-6 md:p-10">
+        <div className="flex justify-start">
+          <Logo url="/" />
+        </div>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="w-full max-w-sm">
+            <ForgotPasswordForm />
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden lg:flex flex-col justify-between bg-[var(--app-dark)] text-white p-12">
+        <div />
+        <div className="space-y-8 max-w-md">
+          <div className="space-y-4">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/80">
+              <span className="w-1.5 h-1.5 rounded-full bg-white inline-block" />
+              Account recovery
+            </div>
+            <h2 className="text-3xl font-bold leading-snug">
+              Recover your <span className="text-white">VoiceyBill</span> access
+            </h2>
+            <p className="text-white/60 leading-relaxed">
+              We’ll send a one-time reset code to your email so you can create a new password.
+            </p>
+          </div>
+
+          <ul className="space-y-3">
+            {highlights.map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <CheckCircle className="w-4 h-4 flex-shrink-0 text-white/60" />
+                <span className="text-sm text-white/80">{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <p className="text-white/30 text-sm">© 2025 VoiceyBill</p>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/auth/reset-password.tsx
+++ b/src/pages/auth/reset-password.tsx
@@ -1,0 +1,57 @@
+import Logo from "@/components/logo/logo";
+import { CheckCircle } from "lucide-react";
+import ResetPasswordForm from "./_component/reset-password-form";
+
+const ResetPassword = () => {
+  const highlights = [
+    "Use the emailed code to verify ownership",
+    "Set a brand new password immediately",
+    "Old reset codes are invalidated on success",
+    "Secure recovery for your account",
+  ];
+
+  return (
+    <div className="min-h-svh grid lg:grid-cols-2">
+      <div className="flex flex-col gap-4 p-6 md:p-10">
+        <div className="flex justify-start">
+          <Logo url="/" />
+        </div>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="w-full max-w-sm">
+            <ResetPasswordForm />
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden lg:flex flex-col justify-between bg-[var(--app-dark)] text-white p-12">
+        <div />
+        <div className="space-y-8 max-w-md">
+          <div className="space-y-4">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/80">
+              <span className="w-1.5 h-1.5 rounded-full bg-white inline-block" />
+              Reset password
+            </div>
+            <h2 className="text-3xl font-bold leading-snug">
+              Set a new <span className="text-white">VoiceyBill</span> password
+            </h2>
+            <p className="text-white/60 leading-relaxed">
+              Enter the reset code we sent to your inbox and choose a new password.
+            </p>
+          </div>
+
+          <ul className="space-y-3">
+            {highlights.map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <CheckCircle className="w-4 h-4 flex-shrink-0 text-white/60" />
+                <span className="text-sm text-white/80">{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <p className="text-white/30 text-sm">© 2025 VoiceyBill</p>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/src/pages/auth/set-new-password.tsx
+++ b/src/pages/auth/set-new-password.tsx
@@ -1,0 +1,60 @@
+import SetNewPasswordForm from "./_component/set-new-password-form";
+import Logo from "@/components/logo/logo";
+import { CheckCircle } from "lucide-react";
+
+const SetNewPassword = () => {
+  const highlights = [
+    "Create a strong password with 6+ characters",
+    "Password encryption protects your data",
+    "Confirm password to prevent typos",
+    "Immediate access after password reset",
+  ];
+
+  return (
+    <div className="min-h-svh grid lg:grid-cols-2">
+      <div className="flex flex-col gap-4 p-6 md:p-10">
+        <div className="flex justify-start">
+          <Logo url="/" />
+        </div>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="w-full max-w-sm">
+            <SetNewPasswordForm />
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden lg:flex flex-col justify-between bg-[var(--app-dark)] text-white p-12">
+        <div />
+        <div className="space-y-8 max-w-md">
+          <div className="space-y-4">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/80">
+              <span className="w-1.5 h-1.5 rounded-full bg-white inline-block" />
+              Security
+            </div>
+            <h2 className="text-3xl font-bold leading-snug">
+              Create a new <span className="text-white">password</span>
+            </h2>
+            <p className="text-white/60 leading-relaxed">
+              Set a strong password to protect your VoiceyBill account and your financial data.
+            </p>
+          </div>
+
+          <ul className="space-y-3">
+            {highlights.map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <CheckCircle className="w-4 h-4 flex-shrink-0 text-white/60" />
+                <span className="text-sm text-white/80">{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="border-t border-white/10 pt-8">
+          <p className="text-xs text-white/50">© 2025 VoiceyBill</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SetNewPassword;

--- a/src/pages/auth/verify-email.tsx
+++ b/src/pages/auth/verify-email.tsx
@@ -1,0 +1,57 @@
+import Logo from "@/components/logo/logo";
+import { CheckCircle } from "lucide-react";
+import VerifyOtpForm from "./_component/verify-otp-form";
+
+const VerifyEmail = () => {
+  const highlights = [
+    "Secure one-time code verification",
+    "Account activation before login",
+    "Resend code if your email took a moment",
+    "Protected onboarding for new users",
+  ];
+
+  return (
+    <div className="min-h-svh grid lg:grid-cols-2">
+      <div className="flex flex-col gap-4 p-6 md:p-10">
+        <div className="flex justify-start">
+          <Logo url="/" />
+        </div>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="w-full max-w-sm">
+            <VerifyOtpForm />
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden lg:flex flex-col justify-between bg-[var(--app-dark)] text-white p-12">
+        <div />
+        <div className="space-y-8 max-w-md">
+          <div className="space-y-4">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/80">
+              <span className="w-1.5 h-1.5 rounded-full bg-white inline-block" />
+              Email verification
+            </div>
+            <h2 className="text-3xl font-bold leading-snug">
+              Activate your <span className="text-white">VoiceyBill</span> account
+            </h2>
+            <p className="text-white/60 leading-relaxed">
+              We send a one-time code to verify your email before you can sign in.
+            </p>
+          </div>
+
+          <ul className="space-y-3">
+            {highlights.map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <CheckCircle className="w-4 h-4 flex-shrink-0 text-white/60" />
+                <span className="text-sm text-white/80">{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <p className="text-white/30 text-sm">© 2025 VoiceyBill</p>
+      </div>
+    </div>
+  );
+};
+
+export default VerifyEmail;

--- a/src/pages/auth/verify-reset-password.tsx
+++ b/src/pages/auth/verify-reset-password.tsx
@@ -1,0 +1,60 @@
+import VerifyResetOtpForm from "./_component/verify-reset-otp-form";
+import Logo from "@/components/logo/logo";
+import { CheckCircle } from "lucide-react";
+
+const VerifyResetPassword = () => {
+  const highlights = [
+    "Verify with a secure one-time code",
+    "Code expires for maximum security",
+    "Password reset in just a few steps",
+    "Your account data remains encrypted",
+  ];
+
+  return (
+    <div className="min-h-svh grid lg:grid-cols-2">
+      <div className="flex flex-col gap-4 p-6 md:p-10">
+        <div className="flex justify-start">
+          <Logo url="/" />
+        </div>
+        <div className="flex flex-1 items-center justify-center">
+          <div className="w-full max-w-sm">
+            <VerifyResetOtpForm />
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden lg:flex flex-col justify-between bg-[var(--app-dark)] text-white p-12">
+        <div />
+        <div className="space-y-8 max-w-md">
+          <div className="space-y-4">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/80">
+              <span className="w-1.5 h-1.5 rounded-full bg-white inline-block" />
+              Verification
+            </div>
+            <h2 className="text-3xl font-bold leading-snug">
+              Verify your <span className="text-white">reset code</span>
+            </h2>
+            <p className="text-white/60 leading-relaxed">
+              Enter the one-time code from your email to verify your identity and reset your password.
+            </p>
+          </div>
+
+          <ul className="space-y-3">
+            {highlights.map((item) => (
+              <li key={item} className="flex items-center gap-3">
+                <CheckCircle className="w-4 h-4 flex-shrink-0 text-white/60" />
+                <span className="text-sm text-white/80">{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="border-t border-white/10 pt-8">
+          <p className="text-xs text-white/50">© 2025 VoiceyBill</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VerifyResetPassword;

--- a/src/routes/common/routePath.tsx
+++ b/src/routes/common/routePath.tsx
@@ -9,6 +9,11 @@ export const isPublicRoute = (pathname: string): boolean => {
 export const AUTH_ROUTES = {
   SIGN_IN: "/sign-in",
   SIGN_UP: "/sign-up",
+  VERIFY_OTP: "/verify-email",
+  FORGOT_PASSWORD: "/forgot-password",
+  VERIFY_RESET_OTP: "/verify-reset-password",
+  SET_NEW_PASSWORD: "/set-new-password",
+  RESET_PASSWORD: "/reset-password",
 };
 
 export const PUBLIC_ROUTES = {

--- a/src/routes/common/routes.tsx
+++ b/src/routes/common/routes.tsx
@@ -1,6 +1,11 @@
 import { AUTH_ROUTES, PROTECTED_ROUTES, PUBLIC_ROUTES } from "./routePath";
 import SignIn from "@/pages/auth/sign-in";
 import SignUp from "@/pages/auth/sign-up";
+import VerifyEmail from "@/pages/auth/verify-email";
+import ForgotPassword from "@/pages/auth/forgot-password";
+import VerifyResetPassword from "@/pages/auth/verify-reset-password";
+import SetNewPassword from "@/pages/auth/set-new-password";
+import ResetPassword from "@/pages/auth/reset-password";
 import Home from "@/pages/home";
 import Dashboard from "@/pages/dashboard";
 import Transactions from "@/pages/transactions";
@@ -17,6 +22,11 @@ export const publicRoutePaths = [
 export const authenticationRoutePaths = [
   { path: AUTH_ROUTES.SIGN_IN, element: <SignIn /> },
   { path: AUTH_ROUTES.SIGN_UP, element: <SignUp /> },
+  { path: AUTH_ROUTES.VERIFY_OTP, element: <VerifyEmail /> },
+  { path: AUTH_ROUTES.FORGOT_PASSWORD, element: <ForgotPassword /> },
+  { path: AUTH_ROUTES.VERIFY_RESET_OTP, element: <VerifyResetPassword /> },
+  { path: AUTH_ROUTES.SET_NEW_PASSWORD, element: <SetNewPassword /> },
+  { path: AUTH_ROUTES.RESET_PASSWORD, element: <ResetPassword /> },
 ];
 
 export const protectedRoutePaths = [


### PR DESCRIPTION
## Summary
Improves the auth experience across the web app with password visibility controls, segmented OTP entry, and a cleaner password reset flow.

## What changed
- Added reusable password inputs with show and hide eye icons.
- Replaced single OTP fields with six-digit segmented OTP inputs.
- Split password reset into a professional multi-step flow.
- Added dedicated screens for verify email, forgot password, verify reset code, and set new password.
- Updated auth routes and RTK Query mutations to match the new flow.
- Preserved the dark sidebar auth layout across the updated screens.

## Validation
- npm run build in voiceyBill-web
- TypeScript checks passed

## Notes
- This PR pairs with the backend auth PR for end-to-end verification and password reset support.
- The branch is pushed and clean.

## Checklist
- [x] UI changes are complete
- [x] Build passes locally
- [x] No secrets or unrelated files included
- [x] Ready for review