### PR TITLE
fix(table): Restore all transaction type filter

### DIFF
--- a/src/components/transaction/transaction-table/index.tsx
+++ b/src/components/transaction/transaction-table/index.tsx
@@ -20,6 +20,7 @@ const TransactionTable = (props: {
   pageSize?: number;
   isShowPagination?: boolean;
 }) => {
+  const ALL_TRANSACTION_TYPES = "ALL_TRANSACTION_TYPES";
   const [filter, setFilter] = useState<FilterType>({
     type: undefined,
     recurringStatus: undefined,
@@ -59,7 +60,10 @@ const TransactionTable = (props: {
     const { type, frequently } = filters;
     setFilter((prev) => ({
       ...prev,
-      type: type as _TransactionType,
+      type:
+        type && type !== ALL_TRANSACTION_TYPES
+          ? (type as _TransactionType)
+          : undefined,
       recurringStatus: frequently as "RECURRING" | "NON_RECURRING",
     }));
   };
@@ -97,6 +101,7 @@ const TransactionTable = (props: {
           key: "type",
           label: "All Types",
           options: [
+            { value: ALL_TRANSACTION_TYPES, label: "All Types" },
             { value: _TRANSACTION_TYPE.INCOME, label: "Income" },
             { value: _TRANSACTION_TYPE.EXPENSE, label: "Expense" },
           ],


### PR DESCRIPTION
## Summary

Adds a real selectable "All Types" option to the transaction type filter. Selecting it clears the type filter, so users can return to all transactions without using the Reset button.

## Related issues

- Closes #21

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [x] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Run `npm ci`.
2. Run `npm run lint`.
3. Run `npm run build`.
4. Start the app with `npm run dev`.
5. Open the transactions table.
6. Select `Income` or `Expense` from the type filter.
7. Reopen the dropdown and select `All Types`.
8. Confirm the table returns to showing all transaction types.

## Validation output

```bash
npm run lint
```

Passed with 0 errors and 7 existing warnings.

```bash
npm run build
```

Passed. Vite reported an existing large chunk size warning.

```bash
npm test --if-present
```

Not run; this project does not define a test script.

## Screenshots or recordings

No screenshots recorded.

## Breaking changes

- [x] No
- [ ] Yes (describe below)

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.