### PR TITLE
fix: Dashboard overview stats cards summary

### DIFF
--- a/src/features/transaction/transactionAPI.ts
+++ b/src/features/transaction/transactionAPI.ts
@@ -76,7 +76,7 @@ export const transactionApi = apiClient.injectEndpoints({
         url: `/transaction/duplicate/${id}`,
         method: "PUT",
       }),
-      invalidatesTags: ["transactions"],
+      invalidatesTags: ["transactions", "analytics"],
     }),
 
     updateTransaction: builder.mutation<void, UpdateTransactionPayload>({
@@ -85,7 +85,7 @@ export const transactionApi = apiClient.injectEndpoints({
         method: "PUT",
         body: transaction,
       }),
-      invalidatesTags: ["transactions"],
+      invalidatesTags: ["transactions", "analytics"],
     }),
 
     bulkImportTransaction: builder.mutation<void, BulkImportTransactionPayload>(
@@ -95,8 +95,8 @@ export const transactionApi = apiClient.injectEndpoints({
           method: "POST",
           body,
         }),
-        invalidatesTags: ["transactions"],
-      }
+        invalidatesTags: ["transactions", "analytics"],
+      },
     ),
 
     deleteTransaction: builder.mutation<void, string>({


### PR DESCRIPTION
## Summary

Dashboard overview cards (Available Balance, Total Income, Total Expenses, Savings Rate) stayed stale after editing a transaction because updateTransaction only invalidated the "transactions" RTK Query tag, not "analytics". Create and delete already invalidated both tags, so the recent transactions list refreshed but analytics queries did not.
This change adds "analytics" to invalidatesTags on updateTransaction, bulkImportTransaction, and duplicateTransaction in transactionAPI.ts, matching create/delete behavior so dashboard stats refetch immediately after those mutations.

## Related issues

- Closes #23
- Related to #

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] ui (components / pages)
- [ ] design (tokens / styles)
- [x] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Start the app (npm run dev) and open the Dashboard.
2. Note the values on the four overview cards (balance, income, expenses, savings rate).
3. Edit a transaction in Recent Transactions (e.g. change amount from $200 to $500) and save.
4. Confirm the transaction list shows the new amount and the overview cards update without a page refresh.

## Media

- [x] I attached screenshots or recordings for visual changes.
- [ ] I linked the issue or discussion that motivated this change.

## Validation output

Paste command outputs:

```bash
npm run lint
npm run build
npm test --if-present
```
<img width="1803" height="626" alt="image" src="https://github.com/user-attachments/assets/cd6f8a00-832f-494b-8215-e6ab5b8b149b" />
<img width="1803" height="626" alt="image" src="https://github.com/user-attachments/assets/b60edb45-12b6-450d-8532-7cddce050ff7" />


## Screenshots or recordings


https://github.com/user-attachments/assets/80d88ea1-5385-40b0-a9b8-f5ab9a94d52c



## Breaking changes

- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [ ] I removed secrets and sensitive information.
