### PR TITLE
fix: Prevent update when no changes are made

### DIFF
--- a/src/pages/settings/_components/account-form.tsx
+++ b/src/pages/settings/_components/account-form.tsx
@@ -49,9 +49,19 @@ export function AccountForm() {
     },
   });
 
+  // Check if there are any changes
+  const hasChanges =
+    form.watch("name") !== user?.name || file !== null;
+
   const onSubmit = (values: AccountFormValues) => {
-    console.log(values);
+
     if (isLoading) return;
+
+    // Prevent submission if no changes
+    if (!hasChanges) {
+      toast.info("No changes to update");
+      return;
+    }
 
     const formData = new FormData();
     formData.append("name", values.name || "");
@@ -69,6 +79,8 @@ export function AccountForm() {
           })
         );
         toast.success("Account updated successfully");
+        setFile(null);
+        setAvatarUrl(null);
       })
       .catch((error) => {
         toast.error(error.data.message || "Failed to update account");
@@ -135,7 +147,7 @@ export function AccountForm() {
             </FormItem>
           )}
         />
-        <Button disabled={isLoading} type="submit">
+        <Button disabled={isLoading || !hasChanges} type="submit">
           {isLoading && <Loader className="h-4 w-4 animate-spin" />}
           Update account
         </Button>


### PR DESCRIPTION
## Summary

Fixed an issue where the "Update account" button was submitting the API request even when no changes were made.
Added change detection logic (hasChanges) to compare current form values (name and profile picture) with existing user data.
Also disabled the submit button when no changes are detected to improve UX and prevent unnecessary API calls.

---

## Related issues

Closes #29



## Issue template used

- [x] Bug report


## Type of change

- [x] fix



## Scope

- [x] ui (components / pages)
- [x] state (Redux / API)


## How to test

1. Open Account Settings page
2. Do not change any field
3. Click "Update account"
   → No API request should be made and a "No changes to update" message should appear

4. Change name or upload a new profile picture
5. Click "Update account"
   → API request should be sent and data should update successfully



## Media

      I attached screenshots or recordings for visual changes
     I linked the issue that motivated this change


## Validation output

bash
npm run lint
npm run build
npm test --if-present

## Breaking changes
   No

https://github.com/user-attachments/assets/19df72a8-b654-4925-95f3-52dac0c8fa69

