### PR TITLE
docs(contributing): Require issue assignment before starting work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for your interest in contributing.
 - Be respectful and constructive in all discussions.
 - Focus pull requests on one clear change.
 - Open an issue before starting major features.
+- Do not start working on any issue without commenting on it first and being assigned. PRs for unassigned issues will be closed.
 - Do not include secrets or production credentials in any commit.
 - Use the issue templates for every new issue. Blank issues are disabled.
 - Use the PR template for every pull request. PRs without the template completed are not considered ready for review.
@@ -68,6 +69,8 @@ When your issue matches one of the templates below, use it. GitHub shows the tem
 Templates are at [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/). If your issue does not fit any template, open a blank issue and describe it clearly. Do not leave required template fields empty.
 
 Keep one issue focused on one topic so it can be triaged quickly. Include a screenshot or recording for anything visual or hard to explain in text.
+
+Before picking up any open issue to work on, comment on the issue to express your interest and wait to be assigned. You can also reach out on Discord first. Do not open a pull request for an issue that has not been assigned to you.
 
 ## Security policy
 


### PR DESCRIPTION
## Summary

Adds a clear rule that contributors must comment on an issue and be assigned before starting work. PRs opened for unassigned issues will be closed. The rule appears in both the Ground rules section and the Issues and templates section.

## Issue template used

- [ ] Bug report
- [ ] Feature request
- [ ] Question
- [x] Other

## Type of change

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [x] docs

## How to test

1. Open CONTRIBUTING.md on the dev branch
2. Verify Ground rules includes the assign-before-work rule
3. Verify Issues and templates section includes the assign-before-work paragraph

## Media

- [ ] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

Documentation change only. No build output required.

## Screenshots or recordings

N/A

## Breaking changes

- [x] No
- [ ] Yes

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.