### PR TITLE
fix(docs): Replace relative cross-repo link with absolute GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ React web dashboard for tracking income and expenses with voice input, AI receip
 - **Node.js 20.0.0 or later** (`node --version` to check)
 - **npm 10.0.0 or later** (`npm --version` to check)
 - Git
-- A running instance of the backend (see [voiceyBill-server README](../voiceyBill-server/README.md))
+- A running instance of the backend (see [voiceyBill-server README](https://github.com/voiceyBill/voiceyBill-server#readme))
 
 > If you don't meet the Node/npm version requirement, download from https://nodejs.org/ (choose the LTS version 20+)
 
@@ -41,7 +41,7 @@ curl http://localhost:8000/health
 # Should return: {"status":"healthy"}
 ```
 
-If this fails, start the backend first in another terminal (see [voiceyBill-server](../voiceyBill-server/README.md)).
+If this fails, start the backend first in another terminal (see [voiceyBill-server](https://github.com/voiceyBill/voiceyBill-server#readme)).
 
 ## Setup
 


### PR DESCRIPTION
## Summary

The README referenced the backend repository using a relative file path (../voiceyBill-server/README.md). Since these are separate repositories, that path never resolves and the links are broken for anyone reading the README on GitHub. Both occurrences have been updated to point to the absolute GitHub URL.

## Issue template used

- [ ] Bug report
- [ ] Feature request
- [ ] Question
- [x] Other

## Type of change

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [x] docs

## How to test

1. Open README.md on the dev branch on GitHub
2. Click both voiceyBill-server links in the Prerequisites and Verify your setup sections
3. Verify they open the voiceyBill-server repository README correctly

## Media

- [ ] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

Documentation change only. No build output required.

## Screenshots or recordings

N/A

## Breaking changes

- [x] No
- [ ] Yes

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.