### PR TITLE
fix(data-table): Prepend reset option to filter dropdown

### DIFF
--- a/src/components/data-table/index.tsx
+++ b/src/components/data-table/index.tsx
@@ -121,7 +121,7 @@ export function DataTable<TData>({
   };
 
   const handleFilterChange = (key: string, value: string) => {
-    const updated = { ...filterValues, [key]: value };
+    const updated = { ...filterValues, [key]: value=== "all" ? "": value };
     setFilterValues(updated);
     onFilterChange?.(updated);
   };
@@ -169,6 +169,7 @@ export function DataTable<TData>({
                 </div>
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value="all">{label}</SelectItem>
                 {options.map((opt) => (
                   <SelectItem key={opt.value} value={opt.value}>
                     {opt.label}


### PR DESCRIPTION
## Summary
The Type filter dropdown in data table was only rendering the options which were passed via the filters prop with no way to reset back to an unfiltered state once Income or Expense was selected. I have added filter's own label as the first SelectItem with value "all", and mapped "all" back to an empty string in handleFilterChange so the existing filter logic stays untouched.

## Related issues

- Closes #21


## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Go to Transactions page.
2. Open the "All Types" filter dropdown.
3. "All Types" will be appearing at the top of the list.
4. Select "Income", table will be filtered to income transactions only.
5. Open the dropdown again, "All Types" will still be there.
6. Select "All Types", all transactions will be returned.

## Media

- [x] I attached screenshots or recordings for visual changes.
- [ ] I linked the issue or discussion that motivated this change.


## Validation output
```
npm run lint
> eslint .
✖ 8 problems (0 errors, 8 warnings)

npm run build
> tsc -b && vite build
✓ built in 27.30s

```

## Screenshots or recordings
https://github.com/user-attachments/assets/7e8ef610-3485-4cf6-aea7-3ec91a52a9c9

## Breaking changes

- [x] No
- [ ] Yes (describe below)


## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [ ] I removed secrets and sensitive information.
