### PR TITLE
fix: The skeleton height not matching the component size.

### DIFF
--- a/src/components/data-table/index.tsx
+++ b/src/components/data-table/index.tsx
@@ -211,7 +211,11 @@ export function DataTable<TData>({
       {/* Table */}
       <div className={cn("rounded-md border overflow-x-auto", className)}>
         {isLoading ? (
-          <TableSkeleton columns={6} rows={6} />
+          <TableSkeleton 
+            columns={columns.length} 
+            rows={data.length > 0 ? data.length : 6} 
+            cellHeight={data.length > 0 ? 48.6 : 52.8}
+          />
         ) : (
           <Table
             className={cn(

--- a/src/components/data-table/index.tsx
+++ b/src/components/data-table/index.tsx
@@ -210,7 +210,11 @@ export function DataTable<TData>({
       {/* Table */}
       <div className={cn("rounded-md border overflow-x-auto", className)}>
         {isLoading ? (
-          <TableSkeleton columns={6} rows={6} />
+          <TableSkeleton 
+            columns={columns.length} 
+            rows={data.length > 0 ? data.length : 6} 
+            cellHeight={data.length > 0 ? 48.6 : 52.8}
+          />
         ) : (
           <Table
             className={cn(

--- a/src/components/data-table/index.tsx
+++ b/src/components/data-table/index.tsx
@@ -211,11 +211,7 @@ export function DataTable<TData>({
       {/* Table */}
       <div className={cn("rounded-md border overflow-x-auto", className)}>
         {isLoading ? (
-          <TableSkeleton 
-            columns={columns.length} 
-            rows={data.length > 0 ? data.length : 6} 
-            cellHeight={data.length > 0 ? 48.6 : 52.8}
-          />
+          <TableSkeleton columns={6} rows={6} />
         ) : (
           <Table
             className={cn(

--- a/src/components/data-table/table-skeleton-loader.tsx
+++ b/src/components/data-table/table-skeleton-loader.tsx
@@ -4,9 +4,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 interface TableSkeletonProps {
   columns: number;
   rows?: number;
+  cellHeight?: number;
 }
 
-const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 25 }) => {
+const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 6, cellHeight = 53 }) => {
   return (
     <div className="w-full bg-background rounded-lg">
       <div className="flex h-10 bg-[var(--surface-alt)] rounded-t-lg">
@@ -18,7 +19,11 @@ const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 25 }) => 
       </div>
       <div className="divide-y divide-[var(--surface-border)]">
         {[...Array(rows)].map((_, rowIndex) => (
-          <div key={`row-${rowIndex}`} className="flex h-10">
+          <div 
+            key={`row-${rowIndex}`} 
+            className="flex"
+            style={{ height: `${cellHeight}px` }}
+          >
             {[...Array(columns)].map((_, colIndex) => (
               <div key={`row-${rowIndex}-col-${colIndex}`} className="flex-1 px-4 py-2">
                 <Skeleton className="h-4 w-full rounded-lg" />

--- a/src/components/data-table/table-skeleton-loader.tsx
+++ b/src/components/data-table/table-skeleton-loader.tsx
@@ -4,9 +4,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 interface TableSkeletonProps {
   columns: number;
   rows?: number;
+  cellHeight?: number;
 }
 
-const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 25 }) => {
+const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 6, cellHeight = 53 }) => {
+
   return (
     <div className="w-full bg-background rounded-lg">
       <div className="flex h-10 bg-[var(--surface-alt)] rounded-t-lg">
@@ -18,7 +20,11 @@ const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 25 }) => 
       </div>
       <div className="divide-y divide-[var(--surface-border)]">
         {[...Array(rows)].map((_, rowIndex) => (
-          <div key={`row-${rowIndex}`} className="flex h-10">
+          <div 
+            key={`row-${rowIndex}`} 
+            className="flex"
+            style={{ height: `${cellHeight}px` }}
+          >
             {[...Array(columns)].map((_, colIndex) => (
               <div key={`row-${rowIndex}-col-${colIndex}`} className="flex-1 px-4 py-2">
                 <Skeleton className="h-4 w-full rounded-lg" />

--- a/src/components/data-table/table-skeleton-loader.tsx
+++ b/src/components/data-table/table-skeleton-loader.tsx
@@ -4,11 +4,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 interface TableSkeletonProps {
   columns: number;
   rows?: number;
-  cellHeight?: number;
 }
 
-const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 6, cellHeight = 53 }) => {
-
+const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 25 }) => {
   return (
     <div className="w-full bg-background rounded-lg">
       <div className="flex h-10 bg-[var(--surface-alt)] rounded-t-lg">
@@ -20,11 +18,7 @@ const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns, rows = 6, cellHe
       </div>
       <div className="divide-y divide-[var(--surface-border)]">
         {[...Array(rows)].map((_, rowIndex) => (
-          <div 
-            key={`row-${rowIndex}`} 
-            className="flex"
-            style={{ height: `${cellHeight}px` }}
-          >
+          <div key={`row-${rowIndex}`} className="flex h-10">
             {[...Array(columns)].map((_, colIndex) => (
               <div key={`row-${rowIndex}-col-${colIndex}`} className="flex-1 px-4 py-2">
                 <Skeleton className="h-4 w-full rounded-lg" />


### PR DESCRIPTION
## Summary

Reduced the number of skeleton loader rows in the DataTable component from 20 to 6 to improve loading UX and prevent unnecessary layout overflow and shift.

I changed the height of the skeleton-loading cell based on the empty-state component. For example, the not-found component has a height of around 300px, while one loading row has a height of about 50px, and the same applies to the table header as well.

## Related issues

- Closes #22 

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (client/src/components/data-table/index.tsx )
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Run `npm ci`.
2. Run `npm run lint`.
3. Run `npm run build`.
4. Start the app with `npm run dev`.
5. Go to Dashboard or Transactions page
6. Trigger loading state (hard refresh or apply/reset filter)
7. Observe the skeleton loader
8. Confirm only 6 placeholder rows are rendered
9. Verify layout remains stable and does not overflow the viewport

## Validation output

```bash
npm run lint
```

Passed with 0 errors and 7 existing warnings.

```bash
npm run build
```

Passed. Vite reported an existing large chunk size warning.

```bash
npm test --if-present
```

Not run; this project does not define a test script.

## Screenshots or recordings

https://github.com/user-attachments/assets/6853774d-9254-4cb9-ad58-bf7667d21493

## Breaking changes

- [x] No
- [ ] Yes (describe below)

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.