### PR TITLE
fix: Disable update preferences button when no changes are made

### DIFF
--- a/src/pages/settings/_components/appearance-theme.tsx
+++ b/src/pages/settings/_components/appearance-theme.tsx
@@ -9,7 +9,6 @@ export function AppearanceTheme() {
 
   const [selectedTheme, setSelectedTheme] = useState(theme)
 
-
   const handleThemeChange = (value: "light" | "dark") => {
     setSelectedTheme(value)
   }
@@ -25,54 +24,64 @@ export function AppearanceTheme() {
         <p className="text-sm text-muted-foreground">
           Select the theme for the dashboard.
         </p>
+
         <RadioGroup
           value={selectedTheme}
           onValueChange={handleThemeChange}
-          className="flex flex-col md:flex-row items-start md:items-center gap-5 max-w-md pt-2"
+          className="flex flex-col items-start gap-5 pt-2 md:flex-row md:items-center max-w-md"
         >
           <div>
             <Label className="flex flex-col [&:has([data-state=checked])>div]:border-primary">
               <RadioGroupItem value="light" className="sr-only" />
+
               <div className="items-center rounded-md border-2 border-muted p-1 hover:border-accent">
                 <div className="space-y-2 rounded-sm bg-[#ecedef] p-2">
                   <div className="space-y-2 rounded-md bg-white p-2 shadow-sm">
-                    <div className="h-2 w-[80px] rounded-lg bg-[#ecedef]" />
-                    <div className="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
+                    <div className="h-2 w-20 rounded-lg bg-[#ecedef]" />
+                    <div className="h-2 w-25 rounded-lg bg-[#ecedef]" />
                   </div>
+
                   <div className="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm">
                     <div className="h-4 w-4 rounded-full bg-[#ecedef]" />
-                    <div className="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
+                    <div className="h-2 w-25 rounded-lg bg-[#ecedef]" />
                   </div>
+
                   <div className="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm">
                     <div className="h-4 w-4 rounded-full bg-[#ecedef]" />
-                    <div className="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
+                    <div className="h-2 w-25 rounded-lg bg-[#ecedef]" />
                   </div>
                 </div>
               </div>
-              <p className="!block w-full p-2 text-center font-normal">
+
+              <p className="block! w-full p-2 text-center font-normal">
                 Light
               </p>
             </Label>
           </div>
+
           <div>
             <Label className="flex flex-col [&:has([data-state=checked])>div]:border-primary">
               <RadioGroupItem value="dark" className="sr-only" />
+
               <div className="items-center rounded-md border-2 border-muted bg-popover p-1 hover:bg-accent hover:text-accent-foreground">
                 <div className="space-y-2 rounded-sm bg-slate-950 p-2">
                   <div className="space-y-2 rounded-md bg-slate-800 p-2 shadow-sm">
-                    <div className="h-2 w-[80px] rounded-lg bg-slate-400" />
-                    <div className="h-2 w-[100px] rounded-lg bg-slate-400" />
+                    <div className="h-2 w-20 rounded-lg bg-slate-400" />
+                    <div className="h-2 w-25 rounded-lg bg-slate-400" />
                   </div>
+
                   <div className="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-sm">
                     <div className="h-4 w-4 rounded-full bg-slate-400" />
-                    <div className="h-2 w-[100px] rounded-lg bg-slate-400" />
+                    <div className="h-2 w-25 rounded-lg bg-slate-400" />
                   </div>
+
                   <div className="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-sm">
                     <div className="h-4 w-4 rounded-full bg-slate-400" />
-                    <div className="h-2 w-[100px] rounded-lg bg-slate-400" />
+                    <div className="h-2 w-25 rounded-lg bg-slate-400" />
                   </div>
                 </div>
               </div>
+
               <p className="block w-full p-2 text-center font-normal">
                 Dark
               </p>
@@ -80,11 +89,15 @@ export function AppearanceTheme() {
           </div>
         </RadioGroup>
       </div>
+
       <Button
-      type="button"
-      className="mt-4"
-      onClick={handleUpdateTheme}
-      >Update preferences</Button>
+        type="button"
+        className="mt-4"
+        onClick={handleUpdateTheme}
+        disabled={selectedTheme === theme}
+      >
+        Update preferences
+      </Button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Fixed a UI/UX bug where the "Update Preferences" button remained enabled even when no changes were made in the Preferences tab.  
Now the button correctly reflects the state of changes and only becomes active when the user modifies the theme selection.

## Related issues

- Closes #61

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [x] state (Redux / API)
- [ ] design (tokens / styles)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open the application
2. Navigate to Settings > Account > Preferences
3. Observe that "Update Preferences" button is disabled on initial load
4. Change theme selection
5. Verify button becomes enabled
6. Revert back to original theme
7. Verify button becomes disabled again

## Media

- [x] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings


https://github.com/user-attachments/assets/1cd087d6-cbc0-41c8-b2b5-637f6c17a19b



## Breaking changes

- [x] No

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
