### PR TITLE
fix(transaction-form): Trim whitespace before title length validation

### DIFF
--- a/src/components/transaction/transaction-form.tsx
+++ b/src/components/transaction/transaction-form.tsx
@@ -50,7 +50,7 @@ import {
 import { toast } from "sonner";
 
 const formSchema = z.object({
-  title: z.string().min(2, { message: "Title must be at least 2 characters." }),
+  title: z.string().trim().min(2, { message: "Title must be at least 2 characters." }),
   amount: z.string().refine((val) => !isNaN(Number(val)) && Number(val) > 0, {
     message: "Amount must be a positive number.",
   }),


### PR DESCRIPTION
## Summary

The Title field in the Manual transaction form accepted 
whitespace-only input (2+ spaces) because Zod's .min(2) 
checks character count without trimming first. I have added 
.trim() before .min(2) in the Zod schema so whitespace 
is stripped before length validation runs. Now, Transactions 
with blank or whitespace-only titles can no longer be saved.

## Related issues

- Closes #63

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open Add Transaction → Manual tab.
2. Enter only spaces (2 or more) in the Title field.
3. Fill all other fields normally.
4. Click Save.
5. Validation error will be appeared and transaction will not be saved.
6. Enter a valid title like "Groceries".
7. Transaction will be saved successfully.

## Media

- [x] I attached screenshots or recordings for visual changes.
- [ ] I linked the issue or discussion that motivated this change.

## Validation output

```bash

npm run lint
> eslint .
✖ 0 errors, 8 warnings (all pre-existing, none in changed file)

npm run build
> tsc -b && vite build
✓ built in 23.99s

``````

## Screenshots or recordings

https://github.com/user-attachments/assets/3856fed8-e60a-4b70-8193-71508b3d0773




## Breaking changes

- [x] No
- [ ] Yes (describe below)


## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [ ] I removed secrets and sensitive information.
