### PR TITLE
fix(sidebar): Remove unused onToggle prop to resolve TypeScript build error

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -19,10 +19,9 @@ interface SidebarProps {
   className?: string;
   onLinkClick?: () => void;
   collapsed?: boolean;
-  onToggle?: () => void;
 }
 
-const Sidebar = ({ className, onLinkClick, collapsed = false, onToggle }: SidebarProps) => {
+const Sidebar = ({ className, onLinkClick, collapsed = false }: SidebarProps) => {
   const { pathname } = useLocation();
   const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false);
   const { onOpenDrawer } = useAddTransactionDrawer();

--- a/src/layouts/app-layout.tsx
+++ b/src/layouts/app-layout.tsx
@@ -18,7 +18,6 @@ const AppLayout = () => {
         <Sidebar
           className="hidden md:flex"
           collapsed={sidebarCollapsed}
-          onToggle={() => setSidebarCollapsed((v) => !v)}
         />
 
         {/* Right Side: Header and Main Content Page Area */}


### PR DESCRIPTION
## Summary
- Removes the unused onToggle prop from SidebarProps interface in sidebar/index.tsx
- Removes the corresponding onToggle call from app-layout.tsx
- Resolves TS6133 build error: onToggle is declared but its value is never read

## Test plan
- Run npm run build and confirm no TypeScript errors
- Verify sidebar toggle still works via the toggle button in the header