### PR TITLE
client: Receipt scan successful

### DIFF
--- a/src/components/transaction/reciept-scanner.tsx
+++ b/src/components/transaction/reciept-scanner.tsx
@@ -48,6 +48,12 @@ const ReceiptScanner = ({
 
     startProgress(10);
     onLoadingChange(true);
+    console.log("Receipt scan started", {
+      fileName: file.name,
+      fileType: file.type,
+      fileSize: file.size,
+    });
+
     // Simulate file upload and processing
     const reader = new FileReader();
     reader.onload = (e) => {
@@ -66,11 +72,22 @@ const ReceiptScanner = ({
       aiScanReceipt(formData)
         .unwrap()
         .then((res) => {
+          console.log("Receipt scan response", res);
+          const errorMessage =
+            res?.data?.error ||
+            (res?.success === false ? res?.message : undefined);
+
+          if (!res?.data || errorMessage) {
+            toast.error(errorMessage || "Failed to scan receipt");
+            return;
+          }
+
           updateProgress(100);
           onScanComplete(res.data);
           toast.success("Receipt scanned successfully");
         })
         .catch((error) => {
+          console.error("Receipt scan request failed", error);
           toast.error(error.data?.message || "Failed to scan receipt");
         })
         .finally(() => {


### PR DESCRIPTION
## Summary

So, there were three issues that I resolved:
1. **Receipt Processing Failure:** Resolved the OpenAI `insufficient_quota` blocking error by making the model name dynamic (`process.env.OPENAI_MODEL`) instead of hardcoded to `gpt-4o`. This allows contributors to use alternative free OpenAI-compatible providers like OpenRouter seamlessly.
2. **Frontend State Misalignment:** Fixed the frontend issue where it would incorrectly display a "scanned successfully" toast notification even if the backend operation failed.
3. **Graceful Backend Error Transmission:** Updated the backend error catch-blocks within the receipt processing lifecycle so that API/Quota exceptions are properly caught and returned to the client rather than causing unhandled request freezes.

## Related issues
- Closes #58

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [x] refactor
- [ ] test
- [ ] chore

## Scope

- [x] backend
- [x] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

1. Configure `.env` with a working OpenRouter or OpenAI API Key and an updated model string (e.g., `google/gemini-2.5-flash`).
2. Run the backend development environment via `npm run dev`.
3. Attempt to upload a receipt image from the web interface.
4. **Success Case:** Verify receipt variables extract cleanly.
5. **Failure Case (To test error handling):** Temporarily break your API key in `.env` and trigger a scan. Confirm the backend accurately forwards the failure and the web frontend displays an error alert instead of a success message.

## Media

- [x] I attached screenshots or recordings when the change affects the UI or visible behavior.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```text
# backend
npm run build && npm test --if-present
```

## Screenshots or recordings
<img width="1350" height="697" alt="image" src="https://github.com/user-attachments/assets/219a5618-a576-43a6-9c75-a34f62853f62" />
<img width="1359" height="645" alt="image" src="https://github.com/user-attachments/assets/12ea3e63-dcca-4eda-8c91-b079fd74316b" />

## Breaking changes

- [x] No
- [ ] Yes (describe below)

