### PR TITLE
Server: Notification feature implemented succesfully using SSE

### DIFF
--- a/src/app/api-client.ts
+++ b/src/app/api-client.ts
@@ -17,6 +17,6 @@ export const apiClient = createApi({
   reducerPath: "api", // Add API client reducer to root reducer
   baseQuery: baseQuery,
   refetchOnMountOrArgChange: true, // Refetch on mount or arg change
-  tagTypes: ["transactions", "analytics", "billingSubscription"], // Tag types for RTK Query
+  tagTypes: ["transactions", "analytics", "billingSubscription", "notifications"], // Tag types for RTK Query
   endpoints: () => ({}), // Endpoints for RTK Query
 });

--- a/src/components/navbar/header-bar.tsx
+++ b/src/components/navbar/header-bar.tsx
@@ -7,6 +7,7 @@ import { Sheet, SheetContent } from "../ui/sheet";
 import { UserNav } from "./user-nav";
 import Sidebar from "../sidebar";
 import Logo from "../logo/logo";
+import NotificationPopover from "./notification-popover";
 
 interface HeaderBarProps {
   onLogoutClick?: () => void;
@@ -70,20 +71,9 @@ export const HeaderBar = ({ onLogoutClick, sidebarCollapsed, onSidebarToggle }: 
             )}
           </Button>
 
-          {/* Notifications bell — hidden on xs */}
-          <div className="relative hidden sm:block">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 sm:h-9 sm:w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted/65 border border-transparent hover:border-border/30 transition-all duration-200"
-              title="Notifications"
-            >
-              <Bell className="h-4 w-4" />
-            </Button>
-            <span className="absolute top-1.5 right-1.5 flex h-1.5 w-1.5">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-brand-green dark:bg-brand-green-light opacity-75"></span>
-              <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-brand-green dark:bg-brand-green-light"></span>
-            </span>
+          {/* Notifications dropdown on desktop */}
+          <div className="hidden sm:block">
+            <NotificationPopover />
           </div>
 
           <div className="h-4 w-px bg-zinc-150/60 dark:bg-white/5 hidden sm:block" />

--- a/src/components/navbar/notification-popover.tsx
+++ b/src/components/navbar/notification-popover.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import { Bell } from "lucide-react";
+import { format } from "date-fns";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { useTypedSelector } from "@/app/hook";
+import {
+  useGetNotificationsQuery,
+  useGetUnreadCountQuery,
+  useMarkAllNotificationsReadMutation,
+} from "@/features/notification/notificationAPI";
+import { formatCurrency } from "@/lib/format-currency";
+
+const NotificationPopover = () => {
+  const { accessToken } = useTypedSelector((state) => state.auth);
+  const [open, setOpen] = useState(false);
+
+  const {
+    data: notificationsData,
+    refetch: refetchNotifications,
+  } = useGetNotificationsQuery(undefined, {
+    skip: !accessToken,
+    refetchOnMountOrArgChange: true,
+  });
+
+  const {
+    data: unreadData,
+    refetch: refetchUnreadCount,
+  } = useGetUnreadCountQuery(undefined, {
+    skip: !accessToken,
+  });
+
+  const [markAllAsRead] = useMarkAllNotificationsReadMutation();
+
+  const unreadCount = unreadData?.count ?? 0;
+  const notifications = notificationsData?.notifications ?? [];
+
+  useEffect(() => {
+    if (!accessToken || !import.meta.env.VITE_API_URL) {
+      return;
+    }
+
+    const baseUrl = import.meta.env.VITE_API_URL.replace(/\/+$/, "");
+    let source: EventSource | null = null;
+    let cancelled = false;
+
+    const openStream = async () => {
+      try {
+        const ticketResponse = await fetch(`${baseUrl}/auth/sse-ticket`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!ticketResponse.ok) {
+          return;
+        }
+
+        const ticketData = await ticketResponse.json();
+        const ticket = ticketData.ticket as string;
+        if (!ticket) {
+          return;
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        source = new EventSource(`${baseUrl}/notification/stream?ticket=${encodeURIComponent(ticket)}`);
+
+        source.onopen = () => {
+          console.debug("SSE connected for notifications");
+          // Ensure we have the latest data as soon as the stream is ready
+          refetchNotifications();
+          refetchUnreadCount();
+        };
+
+        source.addEventListener("notification-created", (e: MessageEvent) => {
+          try {
+            console.debug("SSE event received:", e.data);
+          } catch (err) {
+            console.debug("SSE event received (no data)");
+          }
+          refetchNotifications();
+          refetchUnreadCount();
+        });
+
+        source.onerror = (err) => {
+          console.warn("SSE connection error", err);
+          if (source) {
+            source.close();
+          }
+        };
+      } catch (error) {
+        console.error("Failed to open SSE notification stream", error);
+      }
+    };
+
+    openStream();
+
+    return () => {
+      cancelled = true;
+      if (source) {
+        source.close();
+      }
+    };
+  }, [accessToken, refetchNotifications, refetchUnreadCount]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    // Fetch initial notifications when popover opens
+    refetchNotifications();
+    refetchUnreadCount();
+
+    // If there are unread notifications, mark them as read
+    if (unreadCount > 0) {
+      markAllAsRead();
+    }
+  }, [open, unreadCount, markAllAsRead, refetchNotifications, refetchUnreadCount]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative h-8 w-8 sm:h-9 sm:w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted/65 border border-transparent hover:border-border/30 transition-all duration-200"
+          title="Notifications"
+        >
+          <Bell className="h-4 w-4" />
+
+          {unreadCount > 0 ? (
+            <Badge
+              className="absolute -top-0.5 -right-0.5 min-w-[1rem] h-4 px-1 text-[10px] font-semibold leading-none flex items-center justify-center"
+              variant="destructive"
+            >
+              {unreadCount >= 9 ? "9+" : unreadCount}
+            </Badge>
+          ) : null}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-80 max-h-[440px] overflow-hidden">
+<div className="flex flex-col gap-1 pb-3 border-b border-border/70 mb-3">
+            <p className="text-sm font-semibold">Notifications</p>
+            <p className="text-xs text-muted-foreground">
+              {unreadCount} unread alert{unreadCount === 1 ? "" : "s"}
+            </p>
+        </div>
+
+        <div className="space-y-2 overflow-y-auto max-h-[360px]">
+          {notifications.length === 0 ? (
+            <div className="rounded-xl border border-border/70 bg-background p-4 text-sm text-muted-foreground">
+              No notifications yet.
+            </div>
+          ) : (
+            notifications.map((notification) => (
+              <div
+                key={notification._id}
+                className="rounded-xl border border-border/70 bg-background p-3 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">
+                      {notification.title}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {format(new Date(notification.createdAt), "MMM d, h:mm a")}
+                    </p>
+                  </div>
+
+                  <div className="text-right">
+                    <p
+                      className={`text-sm font-semibold ${
+                        notification.type === "INCOME"
+                          ? "text-emerald-600"
+                          : "text-destructive-600"
+                      }`}
+                    >
+                      {formatCurrency(notification.amount, {
+                        showSign: true,
+                        isExpense: notification.type === "EXPENSE",
+                      })}
+                    </p>
+                    {!notification.isRead ? (
+                      <span className="mt-1 inline-flex rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-semibold text-primary">
+                        New
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default NotificationPopover;

--- a/src/features/notification/notificationAPI.ts
+++ b/src/features/notification/notificationAPI.ts
@@ -1,0 +1,37 @@
+import { apiClient } from "@/app/api-client";
+import type {
+  GetNotificationsResponse,
+  GetUnreadCountResponse,
+} from "./notificationType";
+
+export const notificationApi = apiClient.injectEndpoints({
+  endpoints: (builder) => ({
+    getNotifications: builder.query<GetNotificationsResponse, void>({
+      query: () => ({
+        url: "/notification/all",
+        method: "GET",
+      }),
+      providesTags: ["notifications"],
+    }),
+    getUnreadCount: builder.query<GetUnreadCountResponse, void>({
+      query: () => ({
+        url: "/notification/unread-count",
+        method: "GET",
+      }),
+      providesTags: ["notifications"],
+    }),
+    markAllNotificationsRead: builder.mutation<void, void>({
+      query: () => ({
+        url: "/notification/read-all",
+        method: "PATCH",
+      }),
+      invalidatesTags: ["notifications"],
+    }),
+  }),
+});
+
+export const {
+  useGetNotificationsQuery,
+  useGetUnreadCountQuery,
+  useMarkAllNotificationsReadMutation,
+} = notificationApi;

--- a/src/features/notification/notificationType.ts
+++ b/src/features/notification/notificationType.ts
@@ -1,0 +1,17 @@
+export interface NotificationType {
+  _id: string;
+  transactionId: string;
+  type: "INCOME" | "EXPENSE";
+  title: string;
+  amount: number;
+  isRead: boolean;
+  createdAt: string;
+}
+
+export interface GetNotificationsResponse {
+  notifications: NotificationType[];
+}
+
+export interface GetUnreadCountResponse {
+  count: number;
+}


### PR DESCRIPTION
## Summary

Implemented real-time notifications for transactions using Server-Sent Events (SSE) with secure, single-use ticket authentication. Users now receive instant notification updates (type, amount, timestamp) without page reload. The notification badge and popover UI were also improved for clarity and responsiveness.

## Key Changes

- Added notification model, service, controller, and routes on the backend.
- Implemented secure one-time ticket exchange for SSE authentication (no JWT in URL).
- Used Node.js EventEmitter for in-process real-time event delivery.
- Frontend now exchanges JWT for a ticket, opens an SSE connection, and refetches notifications on new events.
- UI: Notification badge is smaller and more visually balanced.


## Issue template used

- [ ] Bug report
- [X] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [X] feat
- [X] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [X] backend
- [X] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

1. On Backend:
cd voiceyBill-server
npm install
npm run dev


2. On Frontend:
cd voiceyBill-web
npm install
npm run dev

3. Log in on the web app and keep the page open.
4. Create a transaction (income/expense) in another tab or via the UI.
5. Observe:

- Notification badge updates instantly (no refresh needed).
- New notification appears at the top of the popover.
- Unread badge shows correct count (9+ for 9 or more).
- Console logs: "SSE connected for notifications" and "SSE event received:" in browser; "Emit notification..." and "Delivering notification..." in server logs.


## Validation output

Paste relevant command output:

```
# backend
npm run build && npm test --if-present

# client
npm run build && npm run lint

# mobile
npx tsc --noEmit
```


## Checklist

- [[X] PR title follows Conventional Commits style.
- [ ] I used the PR template fully and did not leave required sections blank.
- [ ] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [ ] I removed secrets and sensitive information.
