### PR TITLE
fix(auth): Resolve dark mode inconsistency across authentication pages

### DIFF
--- a/src/pages/auth/_component/forgot-password-form.tsx
+++ b/src/pages/auth/_component/forgot-password-form.tsx
@@ -54,7 +54,7 @@ const ForgotPasswordForm = () => {
           <div className="w-12 h-12 bg-[#F4F4F5] rounded-2xl flex items-center justify-center mb-5">
             <Mail className="w-6 h-6 text-[#015200]" />
           </div>
-          <h1 className="font-display font-bold text-2xl sm:text-3xl text-zinc-900 tracking-tight">
+          <h1 className="font-display font-bold text-2xl sm:text-3xl text-foreground tracking-tight">
             Forgot password?
           </h1>
           <p className="text-sm text-zinc-500 mt-1.5">

--- a/src/pages/auth/_component/reset-password-form.tsx
+++ b/src/pages/auth/_component/reset-password-form.tsx
@@ -76,7 +76,7 @@ const ResetPasswordForm = () => {
           <div className="w-12 h-12 bg-[#F4F4F5] rounded-2xl flex items-center justify-center mb-5">
             <KeyRound className="w-6 h-6 text-[#015200]" />
           </div>
-          <h1 className="font-display font-bold text-2xl sm:text-3xl text-zinc-900 tracking-tight">
+          <h1 className="font-display font-bold text-2xl sm:text-3xl text-foreground tracking-tight">
             Reset password
           </h1>
           <p className="text-sm text-zinc-500 mt-1.5">

--- a/src/pages/auth/_component/signin-form.tsx
+++ b/src/pages/auth/_component/signin-form.tsx
@@ -74,7 +74,7 @@ const SignInForm = ({
       >
         {/* Heading */}
         <div className="mb-2">
-          <h1 className="font-display font-bold text-2xl sm:text-3xl text-zinc-900 tracking-tight">
+          <h1 className="font-display font-bold text-2xl sm:text-3xl text-foreground tracking-tight">
             Welcome back
           </h1>
           <p className="text-sm text-zinc-500 mt-1.5">

--- a/src/pages/auth/_component/signup-form.tsx
+++ b/src/pages/auth/_component/signup-form.tsx
@@ -78,7 +78,7 @@ const SignUpForm = () => {
       <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
         {/* Heading */}
         <div className="mb-2">
-          <h1 className="font-display font-bold text-2xl sm:text-3xl text-zinc-900 tracking-tight">
+          <h1 className="font-display font-bold text-2xl sm:text-3xl text-foreground tracking-tight">
             Create an account
           </h1>
           <p className="text-sm text-zinc-500 mt-1.5">

--- a/src/pages/auth/_component/verify-otp-form.tsx
+++ b/src/pages/auth/_component/verify-otp-form.tsx
@@ -95,7 +95,7 @@ const VerifyOtpForm = () => {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
         <div className="flex flex-col items-center gap-2 text-center">
-          <h1 className="text-2xl font-bold">Verify your email</h1>
+          <h1 className="font-display font-bold text-2xl sm:text-3xl text-foreground tracking-tight">Verify your email</h1>
           <p className="text-balance text-sm text-muted-foreground">
             Enter the 6-digit code sent to your inbox to activate your account.
           </p>

--- a/src/pages/auth/_component/verify-reset-otp-form.tsx
+++ b/src/pages/auth/_component/verify-reset-otp-form.tsx
@@ -66,7 +66,7 @@ const VerifyResetOtpForm = () => {
           <div className="w-12 h-12 bg-[#F4F4F5] rounded-2xl flex items-center justify-center mb-5">
             <ShieldCheck className="w-6 h-6 text-[#015200]" />
           </div>
-          <h1 className="font-display font-bold text-2xl sm:text-3xl text-zinc-900 tracking-tight">
+          <h1 className="font-display font-bold text-2xl sm:text-3xl text-foreground tracking-tight">
             Check your email
           </h1>
           <p className="text-sm text-zinc-500 mt-1.5">

--- a/src/pages/auth/forgot-password.tsx
+++ b/src/pages/auth/forgot-password.tsx
@@ -3,7 +3,7 @@ import ForgotPasswordForm from "./_component/forgot-password-form";
 
 const ForgotPassword = () => {
   return (
-    <div className="home-page-wrapper min-h-svh bg-[#F4F4F5] relative flex items-center justify-center p-4 sm:p-6">
+    <div className="home-page-wrapper min-h-svh bg-background text-foreground relative flex items-center justify-center p-4 sm:p-6">
       {/* Subtle grid texture */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -18,18 +18,26 @@ const ForgotPassword = () => {
         {/* Logo */}
         <div className="flex justify-center mb-8">
           <Link to="/" className="inline-flex items-center gap-2.5">
-            <img src="/logo.png" alt="VoiceyBill" className="w-10 h-10 rounded-full object-cover shrink-0" />
-            <span className="font-display font-bold text-xl tracking-tight text-zinc-900">VoiceyBill</span>
+            <img
+              src="/logo.png"
+              alt="VoiceyBill"
+              className="w-10 h-10 rounded-full object-cover shrink-0"
+            />
+            <span className="font-display font-bold text-xl tracking-tight text-foreground">
+              VoiceyBill
+            </span>
           </Link>
         </div>
 
         {/* Card */}
-        <div className="bg-white rounded-3xl border border-zinc-200/80 shadow-sm p-8 sm:p-10">
+        <div className="bg-card text-card-foreground rounded-3xl border border-border shadow-sm p-8 sm:p-10">
           <ForgotPasswordForm />
         </div>
 
-        <p className="text-center text-xs text-zinc-400 mt-6">
-          <Link to="/" className="hover:text-zinc-600 transition-colors">← Back to home</Link>
+        <p className="text-center text-xs text-muted-foreground mt-6">
+          <Link to="/" className="hover:text-foreground transition-colors">
+            ← Back to home
+          </Link>
         </p>
       </div>
     </div>

--- a/src/pages/auth/reset-password.tsx
+++ b/src/pages/auth/reset-password.tsx
@@ -3,7 +3,7 @@ import ResetPasswordForm from "./_component/reset-password-form";
 
 const ResetPassword = () => {
   return (
-    <div className="home-page-wrapper min-h-svh bg-[#F4F4F5] relative flex items-center justify-center p-4 sm:p-6">
+    <div className="home-page-wrapper min-h-svh bg-background text-foreground relative flex items-center justify-center p-4 sm:p-6">
       {/* Subtle grid texture */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -18,18 +18,26 @@ const ResetPassword = () => {
         {/* Logo */}
         <div className="flex justify-center mb-8">
           <Link to="/" className="inline-flex items-center gap-2.5">
-            <img src="/logo.png" alt="VoiceyBill" className="w-10 h-10 rounded-full object-cover shrink-0" />
-            <span className="font-display font-bold text-xl tracking-tight text-zinc-900">VoiceyBill</span>
+            <img
+              src="/logo.png"
+              alt="VoiceyBill"
+              className="w-10 h-10 rounded-full object-cover shrink-0"
+            />
+            <span className="font-display font-bold text-xl tracking-tight text-foreground">
+              VoiceyBill
+            </span>
           </Link>
         </div>
 
         {/* Card */}
-        <div className="bg-white rounded-3xl border border-zinc-200/80 shadow-sm p-8 sm:p-10">
+        <div className="bg-card text-card-foreground rounded-3xl border border-border shadow-sm p-8 sm:p-10">
           <ResetPasswordForm />
         </div>
 
-        <p className="text-center text-xs text-zinc-400 mt-6">
-          <Link to="/" className="hover:text-zinc-600 transition-colors">← Back to home</Link>
+        <p className="text-center text-xs text-muted-foreground mt-6">
+          <Link to="/" className="hover:text-foreground transition-colors">
+            ← Back to home
+          </Link>
         </p>
       </div>
     </div>

--- a/src/pages/auth/set-new-password.tsx
+++ b/src/pages/auth/set-new-password.tsx
@@ -11,11 +11,12 @@ const SetNewPassword = () => {
   ];
 
   return (
-    <div className="min-h-svh grid lg:grid-cols-2">
+    <div className="min-h-svh grid lg:grid-cols-2 bg-background text-foreground">
       <div className="flex flex-col gap-4 p-6 md:p-10">
         <div className="flex justify-start">
           <Logo url="/" />
         </div>
+
         <div className="flex flex-1 items-center justify-center">
           <div className="w-full max-w-sm">
             <SetNewPasswordForm />
@@ -23,18 +24,21 @@ const SetNewPassword = () => {
         </div>
       </div>
 
-      <div className="hidden lg:flex flex-col justify-between bg-[var(--app-dark)] text-white p-12">
+      <div className="hidden lg:flex flex-col justify-between bg-card text-card-foreground p-12">
         <div />
+
         <div className="space-y-8 max-w-md">
           <div className="space-y-4">
-            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/80">
-              <span className="w-1.5 h-1.5 rounded-full bg-white inline-block" />
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-muted text-muted-foreground">
+              <span className="w-1.5 h-1.5 rounded-full bg-primary inline-block" />
               Security
             </div>
+
             <h2 className="text-3xl font-bold leading-snug">
-              Create a new <span className="text-white">password</span>
+              Create a new <span className="text-primary">password</span>
             </h2>
-            <p className="text-white/60 leading-relaxed">
+
+            <p className="text-muted-foreground leading-relaxed">
               Set a strong password to protect your VoiceyBill account and your financial data.
             </p>
           </div>
@@ -42,15 +46,15 @@ const SetNewPassword = () => {
           <ul className="space-y-3">
             {highlights.map((item) => (
               <li key={item} className="flex items-center gap-3">
-                <CheckCircle className="w-4 h-4 flex-shrink-0 text-white/60" />
-                <span className="text-sm text-white/80">{item}</span>
+                <CheckCircle className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+                <span className="text-sm text-foreground">{item}</span>
               </li>
             ))}
           </ul>
         </div>
 
-        <div className="border-t border-white/10 pt-8">
-          <p className="text-xs text-white/50">© 2025 VoiceyBill</p>
+        <div className="border-t border-border pt-8">
+          <p className="text-xs text-muted-foreground">© 2025 VoiceyBill</p>
         </div>
       </div>
     </div>

--- a/src/pages/auth/sign-in.tsx
+++ b/src/pages/auth/sign-in.tsx
@@ -3,7 +3,7 @@ import SignInForm from "./_component/signin-form";
 
 const SignIn = () => {
   return (
-    <div className="home-page-wrapper min-h-svh bg-[#F4F4F5] relative flex items-center justify-center p-4 sm:p-6">
+    <div className="home-page-wrapper min-h-svh bg-background relative flex items-center justify-center p-4 sm:p-6">
       {/* Subtle grid texture */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -18,18 +18,26 @@ const SignIn = () => {
         {/* Logo */}
         <div className="flex justify-center mb-8">
           <Link to="/" className="inline-flex items-center gap-2.5">
-            <img src="/logo.png" alt="VoiceyBill" className="w-10 h-10 rounded-full object-cover shrink-0" />
-            <span className="font-display font-bold text-xl tracking-tight text-zinc-900">VoiceyBill</span>
+            <img
+              src="/logo.png"
+              alt="VoiceyBill"
+              className="w-10 h-10 rounded-full object-cover shrink-0"
+            />
+            <span className="font-display font-bold text-xl tracking-tight text-foreground">
+              VoiceyBill
+            </span>
           </Link>
         </div>
 
         {/* Card */}
-        <div className="bg-white rounded-3xl border border-zinc-200/80 shadow-sm p-8 sm:p-10">
+        <div className="bg-card text-card-foreground rounded-3xl border border-border shadow-sm p-8 sm:p-10">
           <SignInForm />
         </div>
 
-        <p className="text-center text-xs text-zinc-400 mt-6">
-          <Link to="/" className="hover:text-zinc-600 transition-colors">← Back to home</Link>
+        <p className="text-center text-xs text-muted-foreground mt-6">
+          <Link to="/" className="hover:text-foreground transition-colors">
+            ← Back to home
+          </Link>
         </p>
       </div>
     </div>

--- a/src/pages/auth/sign-up.tsx
+++ b/src/pages/auth/sign-up.tsx
@@ -3,7 +3,7 @@ import SignUpForm from "./_component/signup-form";
 
 const SignUp = () => {
   return (
-    <div className="home-page-wrapper min-h-svh bg-[#F4F4F5] relative flex items-center justify-center p-4 sm:p-6">
+    <div className="home-page-wrapper min-h-svh bg-background relative flex items-center justify-center p-4 sm:p-6">
       {/* Subtle grid texture */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -18,18 +18,26 @@ const SignUp = () => {
         {/* Logo */}
         <div className="flex justify-center mb-8">
           <Link to="/" className="inline-flex items-center gap-2.5">
-            <img src="/logo.png" alt="VoiceyBill" className="w-10 h-10 rounded-full object-cover shrink-0" />
-            <span className="font-display font-bold text-xl tracking-tight text-zinc-900">VoiceyBill</span>
+            <img
+              src="/logo.png"
+              alt="VoiceyBill"
+              className="w-10 h-10 rounded-full object-cover shrink-0"
+            />
+            <span className="font-display font-bold text-xl tracking-tight text-foreground">
+              VoiceyBill
+            </span>
           </Link>
         </div>
 
         {/* Card */}
-        <div className="bg-white rounded-3xl border border-zinc-200/80 shadow-sm p-8 sm:p-10">
+        <div className="bg-card text-card-foreground rounded-3xl border border-border shadow-sm p-8 sm:p-10">
           <SignUpForm />
         </div>
 
-        <p className="text-center text-xs text-zinc-400 mt-6">
-          <Link to="/" className="hover:text-zinc-600 transition-colors">← Back to home</Link>
+        <p className="text-center text-xs text-muted-foreground mt-6">
+          <Link to="/" className="hover:text-foreground transition-colors">
+            ← Back to home
+          </Link>
         </p>
       </div>
     </div>

--- a/src/pages/auth/verify-email.tsx
+++ b/src/pages/auth/verify-email.tsx
@@ -11,7 +11,7 @@ const VerifyEmail = () => {
   ];
 
   return (
-    <div className="min-h-svh grid lg:grid-cols-2">
+    <div className="min-h-svh grid lg:grid-cols-2 bg-background text-foreground">
       <div className="flex flex-col gap-4 p-6 md:p-10">
         <div className="flex justify-start">
           <Logo url="/" />
@@ -23,18 +23,20 @@ const VerifyEmail = () => {
         </div>
       </div>
 
-      <div className="hidden lg:flex flex-col justify-between bg-[var(--app-dark)] text-white p-12">
+      <div className="hidden lg:flex flex-col justify-between bg-card text-card-foreground p-12">
         <div />
         <div className="space-y-8 max-w-md">
           <div className="space-y-4">
-            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/80">
-              <span className="w-1.5 h-1.5 rounded-full bg-white inline-block" />
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold bg-muted text-muted-foreground">
+              <span className="w-1.5 h-1.5 rounded-full bg-primary inline-block" />
               Email verification
             </div>
-            <h2 className="text-3xl font-bold leading-snug">
-              Activate your <span className="text-white">VoiceyBill</span> account
+
+            <h2 className="text-3xl font-bold leading-snug text-foreground">
+              Activate your <span className="text-primary">VoiceyBill</span> account
             </h2>
-            <p className="text-white/60 leading-relaxed">
+
+            <p className="text-muted-foreground leading-relaxed">
               We send a one-time code to verify your email before you can sign in.
             </p>
           </div>
@@ -42,13 +44,14 @@ const VerifyEmail = () => {
           <ul className="space-y-3">
             {highlights.map((item) => (
               <li key={item} className="flex items-center gap-3">
-                <CheckCircle className="w-4 h-4 flex-shrink-0 text-white/60" />
-                <span className="text-sm text-white/80">{item}</span>
+                <CheckCircle className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+                <span className="text-sm text-foreground">{item}</span>
               </li>
             ))}
           </ul>
         </div>
-        <p className="text-white/30 text-sm">© 2025 VoiceyBill</p>
+
+        <p className="text-muted-foreground text-sm">© 2025 VoiceyBill</p>
       </div>
     </div>
   );

--- a/src/pages/auth/verify-reset-password.tsx
+++ b/src/pages/auth/verify-reset-password.tsx
@@ -3,7 +3,7 @@ import VerifyResetOtpForm from "./_component/verify-reset-otp-form";
 
 const VerifyResetPassword = () => {
   return (
-    <div className="home-page-wrapper min-h-svh bg-[#F4F4F5] relative flex items-center justify-center p-4 sm:p-6">
+    <div className="home-page-wrapper min-h-svh bg-background text-foreground relative flex items-center justify-center p-4 sm:p-6">
       {/* Subtle grid texture */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -18,18 +18,26 @@ const VerifyResetPassword = () => {
         {/* Logo */}
         <div className="flex justify-center mb-8">
           <Link to="/" className="inline-flex items-center gap-2.5">
-            <img src="/logo.png" alt="VoiceyBill" className="w-10 h-10 rounded-full object-cover shrink-0" />
-            <span className="font-display font-bold text-xl tracking-tight text-zinc-900">VoiceyBill</span>
+            <img
+              src="/logo.png"
+              alt="VoiceyBill"
+              className="w-10 h-10 rounded-full object-cover shrink-0"
+            />
+            <span className="font-display font-bold text-xl tracking-tight text-foreground">
+              VoiceyBill
+            </span>
           </Link>
         </div>
 
         {/* Card */}
-        <div className="bg-white rounded-3xl border border-zinc-200/80 shadow-sm p-8 sm:p-10">
+        <div className="bg-card text-card-foreground rounded-3xl border border-border shadow-sm p-8 sm:p-10">
           <VerifyResetOtpForm />
         </div>
 
-        <p className="text-center text-xs text-zinc-400 mt-6">
-          <Link to="/" className="hover:text-zinc-600 transition-colors">← Back to home</Link>
+        <p className="text-center text-xs text-muted-foreground mt-6">
+          <Link to="/" className="hover:text-foreground transition-colors">
+            ← Back to home
+          </Link>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixed dark mode inconsistency across authentication pages by replacing hardcoded text colors (e.g. `text-zinc-900`) with theme-aware Tailwind classes such as `text-foreground` and `text-muted-foreground`. This ensures proper visibility and consistent UI in both light and dark themes across all auth-related pages.

## Related issues

- Closes #103

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [x] fix
- [ ] feat
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [x] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Run the application locally
2. Navigate to authentication pages:
   - Sign In
   - Sign Up
   - Forgot Password
   - OTP Verification pages
3. Toggle dark mode in the app
4. Verify that all text and headings are visible and properly styled in both light and dark themes

## Media

- [x] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run lint   # passed
npm run build  # passed
npm test --if-present  # passed
```

## Screenshots or recordings

https://github.com/user-attachments/assets/79ca8136-9f52-4926-b6c3-878728c194ac

## Breaking changes

- [x] No

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
