### PR TITLE
fix(notification): Close popup on outside click

### DIFF
--- a/src/components/navbar/notification-dropdown.tsx
+++ b/src/components/navbar/notification-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Bell, X, Trash2, AlertCircle, AlertTriangle, Info } from "lucide-react";
 import { useTypedSelector, useAppDispatch } from "@/app/hook";
 import { Button } from "../ui/button";
@@ -14,6 +14,24 @@ export const NotificationDropdown = () => {
   const dispatch = useAppDispatch();
   const { notifications } = useTypedSelector((state) => state.notification);
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
 
   const unreadCount = notifications.filter((n) => !n.read).length;
 
@@ -57,7 +75,7 @@ export const NotificationDropdown = () => {
   };
 
   return (
-    <div className="relative">
+    <div className="relative" ref={dropdownRef}>
       <Button
         variant="ghost"
         size="icon"


### PR DESCRIPTION
## Summary
This PR fixes the notification popup behavior by allowing it to close when the user clicks outside of it. Previously, users had to click the notification icon again to close the popup, which caused a poor user experience.

## Related issues
- Closes #106 


## Issue template used
- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change
- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope
- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test
1. Open the application
2. Click on the Notifications icon to open popup
3. Click anywhere outside the popup
4. Verify that popup closes automatically

## Media
- [ ] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings

https://github.com/user-attachments/assets/6b58681c-16c3-4c58-aeeb-7ce9fb91a517

## Breaking changes

- [x] No

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
