### PR TITLE
feat: Add delete account feature with confirmation and API integration

### DIFF
--- a/src/features/user/userAPI.ts
+++ b/src/features/user/userAPI.ts
@@ -17,7 +17,25 @@ export const userApi = apiClient.injectEndpoints({
         body,
       }),
     }),
+    sendDeleteAccountOtp: builder.mutation<{ message: string }, void>({
+      query: () => ({
+        url: '/user/account/otp',
+        method: 'POST',
+      }),
+    }),
+    deleteUser: builder.mutation<{ message: string }, { otp: string }>({
+      query: (payload) => ({
+        url: '/user/account',
+        method: 'DELETE',
+        body: payload,
+      }),
+    }),
   }),
 });
 
-export const { useUpdateUserMutation, useChangePasswordMutation } = userApi;
+export const {
+  useUpdateUserMutation,
+  useChangePasswordMutation,
+  useSendDeleteAccountOtpMutation,
+  useDeleteUserMutation,
+} = userApi;

--- a/src/pages/settings/account.tsx
+++ b/src/pages/settings/account.tsx
@@ -27,27 +27,32 @@ const Account = () => {
   const [deleteOtp, setDeleteOtp] = useState("");
   const [isSendingOtp, setIsSendingOtp] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
   const [sendDeleteAccountOtp] = useSendDeleteAccountOtpMutation();
   const [deleteUser] = useDeleteUserMutation();
+
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
   const handleSendOtp = async () => {
     try {
       setIsSendingOtp(true);
+
       await sendDeleteAccountOtp().unwrap();
+
       toast.success("OTP sent to your email");
     } catch (err: unknown) {
-  const message =
-    typeof err === "object" &&
-    err !== null &&
-    "data" in err &&
-    typeof (err as any).data?.message === "string"
-      ? (err as any).data.message
-      : "Unable to send OTP";
+      const message =
+        typeof err === "object" &&
+        err !== null &&
+        "data" in err &&
+        typeof (err as { data?: { message?: string } }).data?.message ===
+          "string"
+          ? (err as { data?: { message?: string } }).data?.message
+          : "Unable to send OTP";
 
-  toast.error(message);
-}finally {
+      toast.error(message);
+    } finally {
       setIsSendingOtp(false);
     }
   };
@@ -65,21 +70,26 @@ const Account = () => {
 
     try {
       setIsDeleting(true);
+
       await deleteUser({ otp: deleteOtp.trim() }).unwrap();
+
       dispatch(logout());
+
       navigate(PUBLIC_ROUTES.HOME);
+
       toast.success("Account deleted");
     } catch (err: unknown) {
-  const message =
-    typeof err === "object" &&
-    err !== null &&
-    "data" in err &&
-    typeof (err as any).data?.message === "string"
-      ? (err as any).data.message
-      : "Failed to delete account";
+      const message =
+        typeof err === "object" &&
+        err !== null &&
+        "data" in err &&
+        typeof (err as { data?: { message?: string } }).data?.message ===
+          "string"
+          ? (err as { data?: { message?: string } }).data?.message
+          : "Failed to delete account";
 
-  toast.error(message);
-} finally {
+      toast.error(message);
+    } finally {
       setIsDeleting(false);
       setIsOpen(false);
       setConfirmText("");
@@ -91,7 +101,10 @@ const Account = () => {
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-medium">Account</h3>
-        <p className="text-sm text-muted-foreground">Update your account settings.</p>
+
+        <p className="text-sm text-muted-foreground">
+          Update your account settings.
+        </p>
       </div>
 
       <Separator />
@@ -101,10 +114,19 @@ const Account = () => {
       <Separator />
 
       <div className="pt-4">
-        <h4 className="text-sm font-medium text-destructive">Danger Zone</h4>
-        <p className="text-xs text-muted-foreground mt-1">Permanently delete your account and data.</p>
+        <h4 className="text-sm font-medium text-destructive">
+          Danger Zone
+        </h4>
+
+        <p className="mt-1 text-xs text-muted-foreground">
+          Permanently delete your account and data.
+        </p>
+
         <div className="mt-3">
-          <Button variant="destructive" onClick={() => setIsOpen(true)}>
+          <Button
+            variant="destructive"
+            onClick={() => setIsOpen(true)}
+          >
             Delete account
           </Button>
         </div>
@@ -114,8 +136,10 @@ const Account = () => {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Delete account</DialogTitle>
+
             <DialogDescription>
-              This action is permanent. Type <strong>DELETE</strong> below to confirm.
+              This action is permanent. Type <strong>DELETE</strong> below to
+              confirm.
             </DialogDescription>
           </DialogHeader>
 
@@ -127,8 +151,12 @@ const Account = () => {
               placeholder="Type DELETE to confirm"
             />
 
-            <Button variant="outline" onClick={handleSendOtp} disabled={isSendingOtp}>
-              {isSendingOtp ? 'Sending OTP...' : 'Send OTP'}
+            <Button
+              variant="outline"
+              onClick={handleSendOtp}
+              disabled={isSendingOtp}
+            >
+              {isSendingOtp ? "Sending OTP..." : "Send OTP"}
             </Button>
 
             <input
@@ -144,7 +172,12 @@ const Account = () => {
             <DialogClose>
               <Button variant="ghost">Cancel</Button>
             </DialogClose>
-            <Button variant="destructive" onClick={handleConfirmDelete} disabled={isDeleting}>
+
+            <Button
+              variant="destructive"
+              onClick={handleConfirmDelete}
+              disabled={isDeleting}
+            >
               {isDeleting ? "Deleting..." : "Confirm"}
             </Button>
           </DialogFooter>

--- a/src/pages/settings/account.tsx
+++ b/src/pages/settings/account.tsx
@@ -37,9 +37,17 @@ const Account = () => {
       setIsSendingOtp(true);
       await sendDeleteAccountOtp().unwrap();
       toast.success("OTP sent to your email");
-    } catch (err: unknown) {
-      toast.error(err?.data?.message || "Unable to send OTP");
-    } finally {
+    } } catch (err: unknown) {
+  const message =
+    typeof err === "object" &&
+    err !== null &&
+    "data" in err &&
+    typeof (err as any).data?.message === "string"
+      ? (err as any).data.message
+      : "Unable to send OTP";
+
+  toast.error(message);
+}finally {
       setIsSendingOtp(false);
     }
   };
@@ -61,9 +69,17 @@ const Account = () => {
       dispatch(logout());
       navigate(PUBLIC_ROUTES.HOME);
       toast.success("Account deleted");
-    } catch (err: unknown) {
-      toast.error(err?.data?.message || "Failed to delete account");
-    } finally {
+    } } catch (err: unknown) {
+  const message =
+    typeof err === "object" &&
+    err !== null &&
+    "data" in err &&
+    typeof (err as any).data?.message === "string"
+      ? (err as any).data.message
+      : "Failed to delete account";
+
+  toast.error(message);
+} finally {
       setIsDeleting(false);
       setIsOpen(false);
       setConfirmText("");

--- a/src/pages/settings/account.tsx
+++ b/src/pages/settings/account.tsx
@@ -61,7 +61,7 @@ const Account = () => {
       dispatch(logout());
       navigate(PUBLIC_ROUTES.HOME);
       toast.success("Account deleted");
-    } catch (err: any) {
+    } catch (err: unknown) {
       toast.error(err?.data?.message || "Failed to delete account");
     } finally {
       setIsDeleting(false);

--- a/src/pages/settings/account.tsx
+++ b/src/pages/settings/account.tsx
@@ -1,20 +1,141 @@
-import { Separator } from "@/components/ui/separator"
-import { AccountForm } from "./_components/account-form"
+import { useState } from "react";
+import { Separator } from "@/components/ui/separator";
+import { AccountForm } from "./_components/account-form";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import {
+  useDeleteUserMutation,
+  useSendDeleteAccountOtpMutation,
+} from "@/features/user/userAPI";
+import { useAppDispatch } from "@/app/hook";
+import { logout } from "@/features/auth/authSlice";
+import { useNavigate } from "react-router-dom";
+import { PUBLIC_ROUTES } from "@/routes/common/routePath";
+import { toast } from "sonner";
 
 const Account = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [deleteOtp, setDeleteOtp] = useState("");
+  const [isSendingOtp, setIsSendingOtp] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [sendDeleteAccountOtp] = useSendDeleteAccountOtpMutation();
+  const [deleteUser] = useDeleteUserMutation();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const handleSendOtp = async () => {
+    try {
+      setIsSendingOtp(true);
+      await sendDeleteAccountOtp().unwrap();
+      toast.success("OTP sent to your email");
+    } catch (err: any) {
+      toast.error(err?.data?.message || "Unable to send OTP");
+    } finally {
+      setIsSendingOtp(false);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (confirmText.trim() !== "DELETE") {
+      toast.error("Type DELETE to confirm");
+      return;
+    }
+
+    if (!deleteOtp.trim()) {
+      toast.error("Enter the OTP sent to your email");
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      await deleteUser({ otp: deleteOtp.trim() }).unwrap();
+      dispatch(logout());
+      navigate(PUBLIC_ROUTES.HOME);
+      toast.success("Account deleted");
+    } catch (err: any) {
+      toast.error(err?.data?.message || "Failed to delete account");
+    } finally {
+      setIsDeleting(false);
+      setIsOpen(false);
+      setConfirmText("");
+      setDeleteOtp("");
+    }
+  };
+
   return (
     <div className="space-y-6">
-    <div>
-      <h3 className="text-lg font-medium">Account</h3>
-      <p className="text-sm text-muted-foreground">
-        Update your account settings.
-      </p>
+      <div>
+        <h3 className="text-lg font-medium">Account</h3>
+        <p className="text-sm text-muted-foreground">Update your account settings.</p>
+      </div>
+
+      <Separator />
+
+      <AccountForm />
+
+      <Separator />
+
+      <div className="pt-4">
+        <h4 className="text-sm font-medium text-destructive">Danger Zone</h4>
+        <p className="text-xs text-muted-foreground mt-1">Permanently delete your account and data.</p>
+        <div className="mt-3">
+          <Button variant="destructive" onClick={() => setIsOpen(true)}>
+            Delete account
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete account</DialogTitle>
+            <DialogDescription>
+              This action is permanent. Type <strong>DELETE</strong> below to confirm.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="mt-4 space-y-3">
+            <input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              className="w-full rounded-md border p-2"
+              placeholder="Type DELETE to confirm"
+            />
+
+            <Button variant="outline" onClick={handleSendOtp} disabled={isSendingOtp}>
+              {isSendingOtp ? 'Sending OTP...' : 'Send OTP'}
+            </Button>
+
+            <input
+              value={deleteOtp}
+              onChange={(e) => setDeleteOtp(e.target.value)}
+              className="w-full rounded-md border p-2"
+              placeholder="Enter OTP code"
+              maxLength={6}
+            />
+          </div>
+
+          <DialogFooter>
+            <DialogClose>
+              <Button variant="ghost">Cancel</Button>
+            </DialogClose>
+            <Button variant="destructive" onClick={handleConfirmDelete} disabled={isDeleting}>
+              {isDeleting ? "Deleting..." : "Confirm"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
-    <Separator />
-    <AccountForm />
-  </div>
+  );
+};
 
-  )
-}
-
-export default Account
+export default Account;

--- a/src/pages/settings/account.tsx
+++ b/src/pages/settings/account.tsx
@@ -37,7 +37,7 @@ const Account = () => {
       setIsSendingOtp(true);
       await sendDeleteAccountOtp().unwrap();
       toast.success("OTP sent to your email");
-    } } catch (err: unknown) {
+    } catch (err: unknown) {
   const message =
     typeof err === "object" &&
     err !== null &&
@@ -69,7 +69,7 @@ const Account = () => {
       dispatch(logout());
       navigate(PUBLIC_ROUTES.HOME);
       toast.success("Account deleted");
-    } } catch (err: unknown) {
+    } catch (err: unknown) {
   const message =
     typeof err === "object" &&
     err !== null &&

--- a/src/pages/settings/account.tsx
+++ b/src/pages/settings/account.tsx
@@ -37,7 +37,7 @@ const Account = () => {
       setIsSendingOtp(true);
       await sendDeleteAccountOtp().unwrap();
       toast.success("OTP sent to your email");
-    } catch (err: any) {
+    } catch (err: unknown) {
       toast.error(err?.data?.message || "Unable to send OTP");
     } finally {
       setIsSendingOtp(false);


### PR DESCRIPTION
## Summary

This PR introduces a secure **Delete Account feature** in the User Settings > Account section. It allows users to permanently delete their account along with all associated data from the system.

A confirmation dialog has been added to prevent accidental deletions. After initial confirmation, the user must type "DELETE" and request an OTP verification. An OTP is sent to the user's registered email for security verification. The account will only be deleted after successful OTP validation.

On successful deletion, the user session is destroyed, and the user is automatically logged out and redirected to the login/landing page.

This ensures a secure, two-step verification process for account deletion, improving user safety and data protection.

---

## Related issues

- Closes #108  
- Related to #108  

---

## Issue template used

- [ ] Bug report  
- [x] Feature request  
- [ ] Question  
- [ ] Other  

---

## Type of change

- [x] feat  
- [ ] fix  
- [ ] docs  
- [ ] refactor  
- [ ] test  
- [ ] chore  

---

## Scope

- [x] ui (components / pages)  
- [x] state (API / auth flow)  
- [ ] design (tokens / styles)  
- [ ] CI/CD  
- [ ] docs  

---

## How to test

1. Go to **User Settings > Account**
2. Click on **Delete Account** option
3. Confirmation modal/dialog will open
4. Type **"DELETE"** in the input field
5. Click on **Send OTP** button
6. OTP will be sent to the registered email
7. Enter the received OTP in OTP input field
8. Click **Verify OTP**
9. After successful verification:
   - account deletion API is triggered (`DELETE /api/user/account`)
   - user session is destroyed
   - user is logged out automatically
   - user is redirected to login/landing page

---

## Media

- [x] I attached screenshots or recordings for visual changes  
- [x] I linked the issue or discussion that motivated this change  

---

## Validation output

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings


https://github.com/user-attachments/assets/269eadfa-c554-4021-91d8-396f0f5057f5


## Breaking changes

- [x] No

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
