### PR TITLE
feat: Add voice input support for budget setting

### DIFF
--- a/src/pages/budget/_component/budget-form.tsx
+++ b/src/pages/budget/_component/budget-form.tsx
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Loader } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,7 +17,9 @@ import CurrencyInputField from "@/components/ui/currency-input";
 import { CATEGORIES } from "@/constant";
 import { useUpsertBudgetMutation } from "@/features/budget/budgetAPI";
 import { BudgetSummary } from "@/features/budget/budgetType";
+import { AIScanReceiptData } from "@/features/transaction/transationType";
 import { getCategoryIcon } from "@/lib/category-icons";
+import BudgetVoiceRecorder from "./budget-voice-recorder";
 
 const budgetFormSchema = z
   .object({
@@ -68,6 +70,7 @@ interface BudgetFormProps {
   month: number;
   year: number;
   budget?: BudgetSummary;
+  mode?: "voice" | "manual";
   onCloseDrawer?: () => void;
 }
 
@@ -75,9 +78,11 @@ const BudgetForm = ({
   month,
   year,
   budget,
+  mode = "manual",
   onCloseDrawer,
 }: BudgetFormProps) => {
   const [upsertBudget, { isLoading }] = useUpsertBudgetMutation();
+  const [isVoiceProcessing, setIsVoiceProcessing] = useState(false);
 
   const defaultCategoryValues = useMemo(() => {
     return CATEGORIES.reduce<Record<string, string>>((acc, category) => {
@@ -105,6 +110,63 @@ const BudgetForm = ({
       categories: defaultCategoryValues,
     });
   }, [budget, defaultCategoryValues, form]);
+
+  const normalizeText = (value?: string) =>
+    (value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+
+  const findVoiceCategory = (data: AIScanReceiptData) => {
+    const searchableText = normalizeText(
+      [data.category, data.title, data.description, data.transcription]
+        .filter(Boolean)
+        .join(" ")
+    );
+
+    return CATEGORIES.find((category) => {
+      const value = normalizeText(category.value);
+      const label = normalizeText(category.label);
+      return (
+        searchableText === value ||
+        searchableText === label ||
+        searchableText.includes(value) ||
+        searchableText.includes(label)
+      );
+    });
+  };
+
+  const handleVoiceComplete = (data: AIScanReceiptData) => {
+    const amount = Number(data.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      toast.error("Voice did not include a valid budget amount.");
+      return;
+    }
+
+    const amountValue = amount.toString();
+    const matchedCategory = findVoiceCategory(data);
+    const currentTotalBudget = Number(form.getValues("totalBudget"));
+    const shouldSetTotalBudget =
+      !matchedCategory ||
+      !Number.isFinite(currentTotalBudget) ||
+      currentTotalBudget <= 0 ||
+      currentTotalBudget < amount;
+
+    if (shouldSetTotalBudget) {
+      form.setValue("totalBudget", amountValue, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
+
+    if (matchedCategory) {
+      form.setValue(`categories.${matchedCategory.value}`, amountValue, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      toast.success(`${matchedCategory.label} budget filled from voice.`);
+      return;
+    }
+
+    toast.success("Total budget filled from voice.");
+  };
 
   const onSubmit = (values: BudgetFormValues) => {
     const totalBudget = Number(values.totalBudget);
@@ -147,6 +209,14 @@ const BudgetForm = ({
         className="flex h-full min-h-0 flex-col"
       >
         <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-4 pb-4">
+          {mode === "voice" && (
+            <BudgetVoiceRecorder
+              loadingChange={isVoiceProcessing}
+              onLoadingChange={setIsVoiceProcessing}
+              onVoiceComplete={handleVoiceComplete}
+            />
+          )}
+
           <FormField
             control={form.control}
             name="totalBudget"
@@ -156,6 +226,7 @@ const BudgetForm = ({
                 <FormControl>
                   <CurrencyInputField
                     {...field}
+                    disabled={isVoiceProcessing}
                     onValueChange={(value) => field.onChange(value || "")}
                     placeholder="$0.00"
                     prefix="$"
@@ -193,6 +264,7 @@ const BudgetForm = ({
                         <FormControl>
                           <CurrencyInputField
                             {...field}
+                            disabled={isVoiceProcessing}
                             onValueChange={(value) =>
                               field.onChange(value || "")
                             }
@@ -219,7 +291,7 @@ const BudgetForm = ({
           <Button
             type="submit"
             className="w-full"
-            disabled={isLoading}
+            disabled={isLoading || isVoiceProcessing}
           >
             {isLoading ? <Loader className="h-4 w-4 animate-spin" /> : null}
             Save Budget

--- a/src/pages/budget/_component/budget-voice-recorder.tsx
+++ b/src/pages/budget/_component/budget-voice-recorder.tsx
@@ -1,0 +1,327 @@
+import { useRef, useState } from "react";
+import { Mic, Pause, Play, Square } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import { useProgressLoader } from "@/hooks/use-progress-loader";
+import { useProcessVoiceTransactionMutation } from "@/features/transaction/transactionAPI";
+import { AIScanReceiptData } from "@/features/transaction/transationType";
+
+interface BudgetVoiceRecorderProps {
+  loadingChange: boolean;
+  onLoadingChange: (isLoading: boolean) => void;
+  onVoiceComplete: (data: AIScanReceiptData) => void;
+}
+
+const BudgetVoiceRecorder = ({
+  loadingChange,
+  onLoadingChange,
+  onVoiceComplete,
+}: BudgetVoiceRecorderProps) => {
+  const [isRecording, setIsRecording] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [recordingDuration, setRecordingDuration] = useState(0);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [hasProcessedVoice, setHasProcessedVoice] = useState(false);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [processVoiceTransaction] = useProcessVoiceTransactionMutation();
+
+  const {
+    progress,
+    startProgress,
+    updateProgress,
+    doneProgress,
+    resetProgress,
+  } = useProgressLoader({ initialProgress: 10, completionDelay: 500 });
+
+  const clearRecording = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+      audioRef.current.src = "";
+    }
+
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+    }
+
+    setAudioBlob(null);
+    setAudioUrl(null);
+    setRecordingDuration(0);
+    setIsPlaying(false);
+  };
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream, {
+        mimeType: "audio/webm;codecs=opus",
+      });
+      const chunks: BlobPart[] = [];
+
+      mediaRecorderRef.current = mediaRecorder;
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          chunks.push(event.data);
+        }
+      };
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunks, { type: "audio/webm;codecs=opus" });
+        setAudioBlob(blob);
+        setAudioUrl(URL.createObjectURL(blob));
+        stream.getTracks().forEach((track) => track.stop());
+      };
+
+      mediaRecorder.start();
+      setIsRecording(true);
+      setRecordingDuration(0);
+      setHasProcessedVoice(false);
+      intervalRef.current = setInterval(() => {
+        setRecordingDuration((prev) => prev + 1);
+      }, 1000);
+    } catch (error) {
+      toast.error("Could not access microphone. Please check permissions.");
+      console.error("Error accessing microphone:", error);
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current && isRecording) {
+      mediaRecorderRef.current.stop();
+      setIsRecording(false);
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  const playAudio = () => {
+    if (audioUrl && audioRef.current) {
+      audioRef.current.play();
+      setIsPlaying(true);
+    }
+  };
+
+  const pauseAudio = () => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  const formatDuration = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const processVoiceRecording = async () => {
+    if (!audioBlob) {
+      toast.error("No recording found");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("file", audioBlob, "recording.webm");
+
+    startProgress(10);
+    onLoadingChange(true);
+
+    let currentProgress = 10;
+    const interval = setInterval(() => {
+      const increment = currentProgress < 90 ? 15 : 1;
+      currentProgress = Math.min(currentProgress + increment, 90);
+      updateProgress(currentProgress);
+    }, 300);
+
+    try {
+      const result = await processVoiceTransaction(formData).unwrap();
+      if (!result?.success || !result.data) {
+        throw new Error(
+          result?.data?.error ||
+            "Unable to process voice recording. Please try again."
+        );
+      }
+
+      updateProgress(100);
+      onVoiceComplete(result.data);
+      setHasProcessedVoice(true);
+      toast.success("Voice processed! Budget form has been filled.");
+      clearRecording();
+    } catch (error: unknown) {
+      let errorMessage = "Failed to process voice recording";
+
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      } else if (
+        typeof error === "object" &&
+        error !== null &&
+        "data" in error
+      ) {
+        const apiError = error as {
+          data?: { data?: { error?: string }; message?: string };
+        };
+        errorMessage =
+          apiError.data?.data?.error ||
+          apiError.data?.message ||
+          errorMessage;
+      }
+
+      toast.error(
+        errorMessage.includes("timeout")
+          ? "Voice processing timed out. Please try with shorter audio."
+          : errorMessage
+      );
+    } finally {
+      clearInterval(interval);
+      doneProgress();
+      resetProgress();
+      onLoadingChange(false);
+    }
+  };
+
+  const resetAll = () => {
+    clearRecording();
+    setHasProcessedVoice(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Label className="text-sm font-medium">Voice Budget</Label>
+
+      <div className="rounded-lg border p-4">
+        <div className="flex items-center justify-center gap-4">
+          {!isRecording && !audioBlob && !hasProcessedVoice && (
+            <Button
+              type="button"
+              onClick={startRecording}
+              disabled={loadingChange}
+              className="flex items-center gap-2"
+              variant="outline"
+            >
+              <Mic className="h-4 w-4" />
+              Start Recording
+            </Button>
+          )}
+
+          {isRecording && (
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2">
+                <div className="h-3 w-3 animate-pulse rounded-full bg-red-500" />
+                <span className="text-sm font-medium">Recording...</span>
+                <span className="text-sm text-muted-foreground">
+                  {formatDuration(recordingDuration)}
+                </span>
+              </div>
+              <Button
+                onClick={stopRecording}
+                size="sm"
+                variant="destructive"
+                type="button"
+              >
+                <Square className="h-4 w-4" />
+                Stop
+              </Button>
+            </div>
+          )}
+
+          {audioBlob && !loadingChange && !hasProcessedVoice && (
+            <div className="flex w-full flex-col items-center gap-3">
+              <div className="flex items-center justify-center gap-3">
+                <Button
+                  type="button"
+                  onClick={isPlaying ? pauseAudio : playAudio}
+                  size="sm"
+                  variant="outline"
+                  className="flex items-center gap-2"
+                >
+                  {isPlaying ? (
+                    <Pause className="h-4 w-4" />
+                  ) : (
+                    <Play className="h-4 w-4" />
+                  )}
+                  {isPlaying ? "Pause" : "Play"}
+                </Button>
+                <span className="text-sm font-medium text-muted-foreground">
+                  {formatDuration(recordingDuration)}
+                </span>
+                <Button
+                  onClick={clearRecording}
+                  size="sm"
+                  variant="ghost"
+                  type="button"
+                  className="flex items-center gap-2"
+                >
+                  Clear
+                </Button>
+              </div>
+
+              <Button
+                type="button"
+                onClick={processVoiceRecording}
+                size="default"
+                className="w-full max-w-48"
+              >
+                Process Recording
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {hasProcessedVoice && (
+          <div className="flex items-center justify-center">
+            <Button
+              type="button"
+              onClick={resetAll}
+              size="default"
+              variant="outline"
+              className="flex w-full max-w-48 items-center gap-2"
+            >
+              <Mic className="h-4 w-4" />
+              Reset & Start Fresh
+            </Button>
+          </div>
+        )}
+
+        {loadingChange && (
+          <div className="space-y-2">
+            <Progress value={progress} className="h-2" />
+            <p className="text-center text-xs text-muted-foreground">
+              Processing voice budget... {progress}%
+            </p>
+          </div>
+        )}
+
+        {audioUrl && (
+          <audio
+            ref={audioRef}
+            src={audioUrl}
+            onEnded={() => setIsPlaying(false)}
+            onPause={() => setIsPlaying(false)}
+            onPlay={() => setIsPlaying(true)}
+            className="hidden"
+          />
+        )}
+      </div>
+
+      <p className="px-2 text-xs text-muted-foreground">
+        Tip: Say your monthly budget and category amount clearly. Example:
+        "Set my monthly budget to 50000 and groceries limit to 10000."
+      </p>
+    </div>
+  );
+};
+
+export default BudgetVoiceRecorder;

--- a/src/pages/budget/_component/set-budget-drawer.tsx
+++ b/src/pages/budget/_component/set-budget-drawer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { SlidersHorizontal, XIcon } from "lucide-react";
+import { FileTextIcon, MicIcon, SlidersHorizontal, XIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Drawer,
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/drawer";
 import { BudgetSummary } from "@/features/budget/budgetType";
 import BudgetForm from "./budget-form";
+import { cn } from "@/lib/utils";
 
 interface SetBudgetDrawerProps {
   month: number;
@@ -19,11 +20,26 @@ interface SetBudgetDrawerProps {
   budget?: BudgetSummary;
 }
 
+type BudgetMode = "voice" | "manual";
+
+const tabs = [
+  { id: "voice" as BudgetMode, label: "Voice", icon: MicIcon },
+  { id: "manual" as BudgetMode, label: "Manual", icon: FileTextIcon },
+];
+
 const SetBudgetDrawer = ({ month, year, budget }: SetBudgetDrawerProps) => {
   const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<BudgetMode>("voice");
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    if (value) {
+      setMode("voice");
+    }
+  };
 
   return (
-    <Drawer direction="right" open={open} onOpenChange={setOpen}>
+    <Drawer direction="right" open={open} onOpenChange={handleOpenChange}>
       <DrawerTrigger asChild>
         <Button>
           <SlidersHorizontal className="h-4 w-4" />
@@ -37,7 +53,7 @@ const SetBudgetDrawer = ({ month, year, budget }: SetBudgetDrawerProps) => {
               {budget?.hasBudget ? "Update Budget" : "Set Budget"}
             </DrawerTitle>
             <DrawerDescription>
-              Set your monthly spending limit and category limits.
+              Choose how you want to set your monthly budget.
             </DrawerDescription>
           </div>
           <DrawerClose className="absolute right-4 top-4">
@@ -45,11 +61,38 @@ const SetBudgetDrawer = ({ month, year, budget }: SetBudgetDrawerProps) => {
           </DrawerClose>
         </DrawerHeader>
 
+        <div className="flex-shrink-0 px-2 pb-4 sm:px-4">
+          <div className="flex space-x-1 rounded-lg bg-muted p-1">
+            {tabs.map((tab) => {
+              const Icon = tab.icon;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => setMode(tab.id)}
+                  className={cn(
+                    "flex flex-1 cursor-pointer items-center justify-center gap-1 rounded-md px-2 py-2 text-xs font-medium transition-all sm:gap-2 sm:px-3 sm:text-sm",
+                    mode === tab.id
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <Icon className="h-4 w-4 flex-shrink-0" />
+                  <span className="hidden xs:inline sm:inline">
+                    {tab.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         <div className="min-h-0 flex-1">
           <BudgetForm
             month={month}
             year={year}
             budget={budget}
+            mode={mode}
             onCloseDrawer={() => setOpen(false)}
           />
         </div>


### PR DESCRIPTION
## Summary

This PR adds voice input support for the budget setting feature. Users can now set their budget using speech-to-text in addition to manual typing. This improves accessibility, usability, and speeds up the budget entry process.

## Related issues

- Closes #111  
- Related to accessibility improvements in budget input UI

## Issue template used

- [ ] Bug report  
- [x] Feature request  
- [ ] Question  
- [ ] Other  

## Type of change

- [x] feat  
- [ ] fix  
- [ ] docs  
- [ ] refactor  
- [ ] test  
- [ ] chore  

## Scope

- [x] ui (components / pages)  
- [ ] design (tokens / styles)  
- [ ] state (Redux / API)  
- [ ] CI/CD  
- [ ] docs  

## How to test

1. Open the budget setting page  
2. Click on the microphone icon next to the budget input field  
3. Speak a budget value (e.g., "5000" or "monthly budget 10000")  
4. Verify that the spoken text is converted and filled into the input field  
5. Stop microphone and ensure manual typing still works normally  
6. Test in a browser that supports Web Speech API  

## Media

- [x] I attached screenshots or recordings for visual changes.  
- [x] I linked the issue or discussion that motivated this change.  

## Validation output

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings


https://github.com/user-attachments/assets/e1b0039e-8390-4c94-bd60-ea5e62ba51a9



## Breaking changes

- [ ] No

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
