### PR TITLE
fix(client): Align date picker weekday headers

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -20,43 +20,45 @@ function Calendar({
       classNames={{
         months: "flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",
-        caption: "flex justify-center pt-1 relative items-center w-full",
+        month_caption: "flex justify-center pt-1 relative items-center w-full",
         caption_label: "text-sm font-medium",
         nav: "flex items-center gap-1",
-        nav_button: cn(
+        button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "absolute left-1 size-7 bg-transparent p-0 opacity-50 hover:opacity-100 z-10"
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-x-1",
-        head_row: "flex",
-        head_cell:
-          "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: cn(
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "absolute right-1 size-7 bg-transparent p-0 opacity-50 hover:opacity-100 z-10"
+        ),
+        month_grid: "w-full border-collapse space-y-1",
+        weekdays: "flex",
+        weekday:
+          "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem] text-center",
+        week: "flex w-full mt-2",
+        day: cn(
           "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md",
           props.mode === "range"
             ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
             : "[&:has([aria-selected])]:rounded-md"
         ),
-        day: cn(
+        day_button: cn(
           buttonVariants({ variant: "ghost" }),
           "size-8 p-0 font-normal aria-selected:opacity-100"
         ),
-        day_range_start:
+        range_start:
           "day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground",
-        day_range_end:
+        range_end:
           "day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground",
-        day_selected:
+        selected:
           "bg-primary text-primary-foreground hover:!bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
-        day_outside:
+        today: "bg-accent text-accent-foreground",
+        outside:
           "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
-        day_disabled: "text-muted-foreground opacity-50 pointer-events-none",
-        day_range_middle:
+        disabled: "text-muted-foreground opacity-50 pointer-events-none",
+        range_middle:
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        day_hidden: "invisible",
+        hidden: "invisible",
         ...classNames,
       }}
       components={{


### PR DESCRIPTION
## Summary

This PR fixes a bug where the date picker weekday labels (Su, Mo, Tu, etc.) were misaligned and bunched up relative to the date columns.

### Cause
The project uses `react-day-picker` v9, but the `Calendar` component in `src/components/ui/calendar.tsx` was configured with outdated Tailwind class keys (e.g. `table`, `head_row`, `head_cell`, `row`, `cell`, `day`) from v8. Consequently, the library's layout defaults were used without styling, resulting in alignment issues (such as `MoTuWeThFrSa` being grouped together without a flex layout or spacing).

### Solution
Updated the `classNames` mapping in `src/components/ui/calendar.tsx` to match the `react-day-picker` v9 API:
- Replaced `table` with `month_grid` (using `space-y-1` instead of the incorrect `space-x-1`)
- Replaced `head_row` with `weekdays`
- Replaced `head_cell` with `weekday` (including `text-center`)
- Replaced `row` with `week`
- Replaced `cell` with `day`
- Replaced `day` with `day_button`
- Replaced modifier states (e.g., `day_selected`, `day_today`) with their v9 equivalents (`selected`, `today`, etc.)

## Related issues

- Closes #97

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [x] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open the Add Transaction drawer by clicking "Add Transaction" on the sidebar and selecting the "Manual" tab.
2. Click the "Date" field to open the date picker popup.
3. Verify that the weekday labels (Su, Mo, Tu, We, Th, Fr, Sa) are aligned properly above each date column.

## Media

- [x] I attached screenshots or recordings for visual changes.
- [ ] I linked the issue or discussion that motivated this change.

## Media

https://github.com/user-attachments/assets/739a3de1-0d38-4272-9c1b-e46431bcebc7

## Validation output

```bash
npm run build
```

## Output :
✓ 3024 modules transformed.
dist/index.html                     1.45 kB │ gzip:   0.62 kB      
dist/assets/index-DirjkvE5.css    135.22 kB │ gzip:  21.18 kB     


## Breaking changes

- [x] No
- [ ] Yes (describe below)
 
 ## Checklist

[✓] PR title follows Conventional Commits style.
[✓] I used the PR template fully and did not leave required sections blank.
[✓] I kept this PR focused and reviewable.
[ ] I added or updated tests where needed.
[ ] I updated documentation where needed.
[ ] I removed secrets and sensitive information.
