### PR TITLE
fix(budget): Format budget usage percentage 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5131,6 +5131,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5977,6 +5994,18 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",

--- a/src/pages/budget/index.tsx
+++ b/src/pages/budget/index.tsx
@@ -17,6 +17,7 @@ import { addBudgetAlerts } from "@/features/notification/notificationSlice";
 import { getCategoryIcon } from "@/lib/category-icons";
 import DeleteBudgetButton from "./_component/delete-budget-button";
 import SetBudgetDrawer from "./_component/set-budget-drawer";
+import { formatPercentage } from "@/lib/format-percentage";
 
 const getCurrentMonthYear = () => {
   const now = new Date();
@@ -164,7 +165,9 @@ export default function Budget() {
     },
     {
       label: "Usage",
-      value: `${budget?.usagePercentage || 0}%`,
+      value: formatPercentage(budget?.usagePercentage || 0, {
+        decimalPlaces: 1,
+      }),
       progress: budget?.usagePercentage || 0,
       tone: getBudgetTone(budget?.usagePercentage || 0),
     },


### PR DESCRIPTION
## Summary


- Use the existing `formatPercentage` utility for the Budget Usage card
- Formatted usage percentages consistently with other areas of the application
- Prevent raw floating-point values from being displayed

## Related issues

- Closes #127 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Start the application locally.
2. Navigate to the Budget page
3. Update budget and add expenses that result in a usage percentage with many decimal places (e.g. 35/1000 = 3.5000000000000004%)
4. Verify that the Usage card displays only formatted percentage value (e.g. 3.5%) instead of the raw floating-point value.
5. Verify that budget calculations and progress bars continue to work correctly.

 ### Before: 
<img width="1575" height="305" alt="image" src="https://github.com/user-attachments/assets/fdd7a808-8fbb-4c53-aab0-c4e3de52702f" />

### After
<img width="1575" height="314" alt="image" src="https://github.com/user-attachments/assets/f8b88d97-6a5b-4d21-9d5a-161ee3e27c11" />

## Media

- [x] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

Paste command outputs:

```bash
npm run lint
npm run build
no tests
```

## Breaking changes

- [x] No
- [ ] Yes (describe below)

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
