### PR TITLE
feat(budget): Add interactive category-wise pie chart

### DIFF
--- a/src/pages/budget/index.tsx
+++ b/src/pages/budget/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from "react";
 import PageLayout from "@/components/page-layout";
 import { Card, CardContent } from "@/components/ui/card";
+import { Cell, Label, Pie, PieChart } from "recharts";
 import {
   Select,
   SelectContent,
@@ -9,9 +10,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 import { AlertTriangle, WalletCards } from "lucide-react";
 import { CATEGORIES } from "@/constant";
 import { useGetBudgetSummaryQuery } from "@/features/budget/budgetAPI";
+import type { BudgetCategorySummary } from "@/features/budget/budgetType";
 import { useAppDispatch } from "@/app/hook";
 import { addBudgetAlerts } from "@/features/notification/notificationSlice";
 import { getCategoryIcon } from "@/lib/category-icons";
@@ -59,6 +67,25 @@ const formatCurrency = (amount: number) =>
 const getCategoryLabel = (name: string) =>
   CATEGORIES.find((category) => category.value === name)?.label || name;
 
+const BUDGET_CATEGORY_COLORS = [
+  "#166114",
+  "#2563eb",
+  "#d97706",
+  "#dc2626",
+  "#7c3aed",
+  "#0891b2",
+  "#0f766e",
+  "#be123c",
+  "#4d7c0f",
+  "#9333ea",
+  "#b45309",
+  "#475569",
+];
+
+const chartConfig = {
+  spent: { label: "Spent" },
+} satisfies ChartConfig;
+
 function BudgetProgress({
   value,
   tone = "safe",
@@ -89,6 +116,244 @@ const getBudgetTone = (percentage: number): BudgetTone => {
   if (percentage >= 70) return "warning";
   return "safe";
 };
+
+function BudgetCategoryDistribution({
+  categories,
+  totalSpent,
+}: {
+  categories: BudgetCategorySummary[];
+  totalSpent: number;
+}) {
+  const categoryData = useMemo(
+    () =>
+      categories.map((category, index) => ({
+        ...category,
+        label: getCategoryLabel(category.name),
+        fill: BUDGET_CATEGORY_COLORS[index % BUDGET_CATEGORY_COLORS.length],
+        sharePercentage:
+          totalSpent > 0 ? Number(((category.spent / totalSpent) * 100).toFixed(1)) : 0,
+      })),
+    [categories, totalSpent]
+  );
+
+  const chartData = categoryData.filter((category) => category.spent > 0);
+
+  return (
+    <Card className="overflow-hidden rounded-lg py-0 shadow-none">
+      <CardContent className="p-0">
+        <div className="border-b border-border px-5 py-4">
+          <h3 className="text-base font-semibold text-foreground">
+            Category Budgets
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Track category distribution, limits, and usage.
+          </p>
+        </div>
+
+        {chartData.length === 0 ? (
+          <div className="flex min-h-[260px] flex-col items-center justify-center px-6 py-10 text-center">
+            <div className="mb-4 rounded-full bg-muted p-4">
+              <WalletCards className="h-8 w-8 text-muted-foreground" />
+            </div>
+            <h4 className="text-sm font-semibold text-foreground">
+              No category spending yet
+            </h4>
+            <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+              Category distribution will appear when expenses are recorded.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-6 p-5 lg:grid-cols-[minmax(300px,0.95fr)_minmax(360px,1.25fr)]">
+            <div className="min-w-0">
+              <ChartContainer
+                config={chartConfig}
+                className="mx-auto aspect-square h-[280px] max-h-[280px] w-full"
+              >
+                <PieChart>
+                  <ChartTooltip
+                    cursor={false}
+                    content={
+                      <ChartTooltipContent
+                        className="rounded-xl border border-border bg-card p-2.5 shadow-lg"
+                        hideLabel
+                        formatter={(_, __, item) => {
+                          const payload = item.payload as (typeof categoryData)[number];
+
+                          return (
+                            <div className="grid gap-1">
+                              <div className="flex items-center gap-2 font-semibold text-foreground">
+                                <span
+                                  className="h-2.5 w-2.5 rounded-full"
+                                  style={{ backgroundColor: payload.fill }}
+                                />
+                                {payload.label}
+                              </div>
+                              <div className="text-muted-foreground">
+                                {formatCurrency(payload.spent)} /{" "}
+                                {formatCurrency(payload.limit)}
+                              </div>
+                              <div
+                                className={
+                                  payload.exceeded
+                                    ? "font-medium text-red-600"
+                                    : "text-muted-foreground"
+                                }
+                              >
+                                {Math.round(payload.usagePercentage)}% usage,{" "}
+                                {payload.sharePercentage}% of spending
+                              </div>
+                            </div>
+                          );
+                        }}
+                      />
+                    }
+                  />
+                  <Pie
+                    data={chartData}
+                    dataKey="spent"
+                    nameKey="label"
+                    innerRadius={72}
+                    outerRadius={98}
+                    paddingAngle={2}
+                    stroke="transparent"
+                    strokeWidth={0}
+                  >
+                    {chartData.map((category) => (
+                      <Cell key={category.name} fill={category.fill} />
+                    ))}
+                    <Label
+                      content={({ viewBox }) => {
+                        if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                          const cx = viewBox.cx ?? 0;
+                          const cy = viewBox.cy ?? 0;
+
+                          return (
+                            <text
+                              x={cx}
+                              y={cy}
+                              textAnchor="middle"
+                              dominantBaseline="middle"
+                            >
+                              <tspan
+                                x={cx}
+                                y={cy - 4}
+                                className="fill-foreground text-2xl font-bold"
+                              >
+                                {formatCurrency(totalSpent)}
+                              </tspan>
+                              <tspan
+                                x={cx}
+                                y={cy + 18}
+                                className="fill-muted-foreground text-xs font-medium"
+                              >
+                                Total Spent
+                              </tspan>
+                            </text>
+                          );
+                        }
+                      }}
+                    />
+                  </Pie>
+                </PieChart>
+              </ChartContainer>
+
+              <div className="mt-4 flex flex-wrap gap-2 border-t border-border pt-4">
+                {chartData.map((category) => (
+                  <div
+                    key={category.name}
+                    className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs"
+                  >
+                    <span
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: category.fill }}
+                    />
+                    <span className="max-w-[150px] truncate font-medium text-foreground">
+                      {category.label}
+                    </span>
+                    <span className="font-semibold text-muted-foreground">
+                      {category.sharePercentage}%
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="max-h-[460px] space-y-3 overflow-y-auto pr-1">
+              {categoryData.map((category) => {
+                const Icon = getCategoryIcon(category.name);
+
+                return (
+                  <div
+                    key={category.name}
+                    className={
+                      category.exceeded
+                        ? "overflow-hidden rounded-lg border border-red-200 bg-red-50 dark:border-red-500/40 dark:bg-red-500/10"
+                        : "overflow-hidden rounded-lg border border-border bg-background"
+                    }
+                  >
+                    {category.exceeded && (
+                      <div className="flex items-center justify-between bg-red-500 px-4 py-2.5 text-white">
+                        <div className="flex items-center gap-2 text-sm font-semibold">
+                          <AlertTriangle className="h-4 w-4" />
+                          <span>Exceeded Limit!</span>
+                        </div>
+                        <span className="text-xs font-medium">Exceeded</span>
+                      </div>
+                    )}
+                    <div className="flex items-center gap-3 p-4">
+                      <div
+                        className="h-10 w-1 shrink-0 rounded-full"
+                        style={{ backgroundColor: category.fill }}
+                      />
+                      <div
+                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full"
+                        style={{ backgroundColor: `${category.fill}1F` }}
+                      >
+                        <Icon className="h-4 w-4" style={{ color: category.fill }} />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-semibold text-foreground">
+                          {category.label}
+                        </p>
+                        <p className="mt-1 text-xs font-medium text-muted-foreground">
+                          Spent:{" "}
+                          <span className="font-semibold text-foreground">
+                            {formatCurrency(category.spent)} /{" "}
+                            {formatCurrency(category.limit)}
+                          </span>
+                        </p>
+                        <div className="mt-3">
+                          <BudgetProgress
+                            value={category.usagePercentage}
+                            tone={getBudgetTone(category.usagePercentage)}
+                          />
+                        </div>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <p
+                          className={
+                            category.exceeded
+                              ? "text-sm font-bold text-red-600"
+                              : "text-sm font-bold text-foreground"
+                          }
+                        >
+                          {Math.round(category.usagePercentage)}%
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {category.sharePercentage}% share
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
 
 function BudgetPageSkeleton() {
   return (
@@ -267,67 +532,10 @@ export default function Budget() {
 
 
           {budget.hasBudget && (
-            <section className="space-y-4">
-              <h3 className="text-base font-semibold text-foreground">
-                Category Budgets
-              </h3>
-
-              <div className="grid gap-4 lg:grid-cols-3">
-                {budget.categories.map((category) => (
-                  <Card
-                    key={category.name}
-                    className={
-                      category.exceeded
-                        ? "gap-0 overflow-hidden rounded-lg border-red-100 py-0 shadow-none"
-                        : "gap-4 rounded-lg py-4 shadow-none"
-                    }
-                  >
-                    {category.exceeded && (
-                      <div className="flex items-center justify-between bg-red-500 px-4 py-3 text-white">
-                        <div className="flex items-center gap-2 font-semibold">
-                          <AlertTriangle className="h-4 w-4" />
-                          <span>Exceeded Limit!</span>
-                        </div>
-                        <span className="text-xs font-medium">Exceeded</span>
-                      </div>
-                    )}
-                    <CardContent
-                      className={
-                        category.exceeded
-                          ? "space-y-3 px-4 py-4"
-                          : "space-y-3 px-5"
-                      }
-                    >
-                      <div className="space-y-1">
-                        <div className="flex items-center gap-2">
-                          {(() => {
-                            const Icon = getCategoryIcon(category.name);
-                            return <Icon className="h-4 w-4 text-muted-foreground" />;
-                          })()}
-                          <p className="font-semibold text-foreground">
-                            {getCategoryLabel(category.name)}
-                          </p>
-                        </div>
-                        <div className="text-sm font-medium text-foreground">
-                          <p>Limit: {formatCurrency(category.limit)}</p>
-                          <p>
-                            Spent:{" "}
-                            <span className="font-bold">
-                              {formatCurrency(category.spent)} /{" "}
-                              {formatCurrency(category.limit)}
-                            </span>
-                          </p>
-                        </div>
-                      </div>
-                      <BudgetProgress
-                        value={category.usagePercentage}
-                        tone={getBudgetTone(category.usagePercentage)}
-                      />
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            </section>
+            <BudgetCategoryDistribution
+              categories={budget.categories}
+              totalSpent={budget.spent}
+            />
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

This PR adds an interactive pie chart to the Budget page to provide a visual representation of category-wise spending distribution. The chart is integrated with existing budget data and summary cards, helping users quickly identify high-expense categories and better understand overall spending patterns.

## Related issues

- Closes #143
- Related to #143

## Issue template used

- [ ] Bug report
- [x] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [x] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Navigate to the Budget page.
2. Verify that the pie chart is displayed alongside the summary cards and category list.
3. Confirm each budget category is represented by a distinct color-coded slice.
5. Verify category list color indicators match the corresponding chart slices.
6. Add, edit, or delete a transaction and confirm the chart updates automatically.
7. Add, edit, or delete a budget category and verify chart data refreshes correctly.
8. Ensure Total Budget, Spent, Remaining, and Usage values remain consistent with chart data.
9. Verify the legend displays category names and percentages correctly.
10. Test responsiveness across different screen sizes.

## Media

- [ ] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings

<img width="1279" height="467" alt="image" src="https://github.com/user-attachments/assets/1b652517-a7da-4c4b-aa77-d019061b1b1b" />

## Breaking changes

- [x] No


## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.