### PR TITLE
fix(table): Refine pagination responsiveness for narrow screens, tablets, and mid-screen devices

### DIFF
--- a/src/components/data-table/table-pagination.tsx
+++ b/src/components/data-table/table-pagination.tsx
@@ -39,96 +39,97 @@ export function DataTablePagination({
   };
 
   return (
-    <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4 px-2">
-      {/* Showing X to Y of Z Rows */}
-      <div className="flex-1 text-sm text-muted-foreground">
-        Showing {(pageNumber - 1) * pageSize + 1}-
-        {Math.min(pageNumber * pageSize, totalCount)} of {totalCount}
-      </div>
-      <div className="flex flex-col lg:flex-row lg:items-center space-y-2 lg:space-x-8 lg:space-y-0">
-        {/* Rows Per Page Selector */}
-        <div className="flex items-center space-x-2">
-          <p className="text-sm font-medium">Rows per page</p>
-          <Select
-            value={`${pageSize}`}
-            onValueChange={(value) => {
+    <div className="flex flex-col gap-4 px-2 w-full">
+      {/* Row 1: Showing info, Rows per page, and Page status */}
+      <div className="flex flex-col min-[900px]:flex-row min-[900px]:items-center justify-between gap-3 text-sm text-muted-foreground w-full">
+        {/* Left: Showing info */}
+        <div className="text-center min-[900px]:text-left whitespace-nowrap">
+          Showing {(pageNumber - 1) * pageSize + 1}-
+          {Math.min(pageNumber * pageSize, totalCount)} of {totalCount}
+        </div>
+
+        {/* Right: Rows per page and Page status */}
+        <div className="flex flex-col min-[340px]:flex-row items-center justify-center gap-2 min-[340px]:gap-4 font-medium text-foreground whitespace-nowrap">
+          <div className="flex items-center space-x-2">
+            <p className="whitespace-nowrap text-muted-foreground">Rows per page</p>
+            <Select
+              value={`${pageSize}`}
+              onValueChange={(value) => {
                 const size = Number(value);
                 onPageChange?.(1);
                 handlePageSizeChange(size);
-            }}
-          >
-            <SelectTrigger className="h-8 w-[70px]">
-              <SelectValue placeholder={`${pageSize}`} />
-            </SelectTrigger>
-            <SelectContent side="top">
-              {[10, 20, 30, 40, 50].map((size) => (
-                <SelectItem key={size} value={`${size}`}>
-                  {size}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* Page Info */}
-        <div className="flex items-center">
-          <div className="flex lg:w-[100px] items-center justify-center text-sm font-medium">
+              }}
+            >
+              <SelectTrigger className="h-8 w-[70px]">
+                <SelectValue placeholder={`${pageSize}`} />
+              </SelectTrigger>
+              <SelectContent side="top">
+                {[10, 20, 30, 40, 50].map((size) => (
+                  <SelectItem key={size} value={`${size}`}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <span className="hidden min-[340px]:inline text-border">|</span>
+          <div className="text-muted-foreground">
             Page {pageNumber} of {totalPages}
           </div>
-
-          {/* Pagination Controls */}
-          <div className="flex items-center space-x-2">
-            <Button
-              variant="outline"
-              className=""
-              size="sm"
-              onClick={() => handlePageChange(pageNumber - 1)}
-              disabled={pageNumber === 1}
-            >
-              <span className="sr-only">Go to previous page</span>
-              <ChevronLeft /> Previous
-            </Button>
-
-            <div className="flex items-center space-x-1">
-            {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-              let pageNum;
-              if (totalPages <= 5) {
-                pageNum = i + 1;
-              } else if (pageNumber <= 3) {
-                pageNum = i + 1;
-              } else if (pageNumber >= totalPages - 2) {
-                pageNum = totalPages - 4 + i;
-              } else {
-                pageNum = pageNumber - 2 + i;
-              }
-
-              return (
-                <Button
-                  key={pageNum}
-                  variant={pageNumber === pageNum ? "default" : "outline"}
-                  className="h-8 w-8 p-0"
-                  onClick={() => handlePageChange(pageNum)}
-                >
-                  {pageNum}
-                </Button>
-              );
-            })}
-          </div>
-
-
-            <Button
-              variant="outline"
-              className=""
-              size="sm"
-              onClick={() => handlePageChange(pageNumber + 1)}
-              disabled={pageNumber >= totalPages}
-            >
-              <span className="sr-only">Go to next page</span>
-              Next
-              <ChevronRight />
-            </Button>
-          </div>
         </div>
+      </div>
+
+      {/* Row 2: Pagination Buttons */}
+      <div className="flex items-center justify-center space-x-2 pt-2 border-t border-border/20">
+        <Button
+          variant="outline"
+          className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+          size="sm"
+          onClick={() => handlePageChange(pageNumber - 1)}
+          disabled={pageNumber === 1}
+        >
+          <span className="sr-only">Go to previous page</span>
+          <ChevronLeft className="h-4 w-4" />
+          <span className="hidden sm:inline ml-1">Previous</span>
+        </Button>
+
+        <div className="flex items-center space-x-1">
+          {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+            let pageNum;
+            if (totalPages <= 5) {
+              pageNum = i + 1;
+            } else if (pageNumber <= 3) {
+              pageNum = i + 1;
+            } else if (pageNumber >= totalPages - 2) {
+              pageNum = totalPages - 4 + i;
+            } else {
+              pageNum = pageNumber - 2 + i;
+            }
+
+            return (
+              <Button
+                key={pageNum}
+                variant={pageNumber === pageNum ? "default" : "outline"}
+                className="h-8 w-8 p-0"
+                onClick={() => handlePageChange(pageNum)}
+              >
+                {pageNum}
+              </Button>
+            );
+          })}
+        </div>
+
+        <Button
+          variant="outline"
+          className="h-8 w-8 p-0 sm:w-auto sm:px-3"
+          size="sm"
+          onClick={() => handlePageChange(pageNumber + 1)}
+          disabled={pageNumber >= totalPages}
+        >
+          <span className="sr-only">Go to next page</span>
+          <span className="hidden sm:inline mr-1">Next</span>
+          <ChevronRight className="h-4 w-4" />
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

This PR applies fine-grained responsive layout rules to the table pagination component in `src/components/data-table/table-pagination.tsx` to handle highly constrained viewports (under 340px), medium devices (iPad Mini at 768px), and the 900px-1030px width range.

### Changes
1. **Vertical Stacking under 340px:**
   - The Rows-per-page dropdown and Page X of Y indicator stack vertically (`flex-col`) on viewports under 340px, and the divider vertical bar `|` is dynamically hidden (`hidden min-[340px]:inline`). This keeps the component narrow (~240px wide) and prevents horizontal page-edge overflow on small screen sizes.
2. **Horizontal Metadata on 900px to 1030px:**
   - Switched Row 1's responsive breakpoint to `min-[900px]:flex-row` and `min-[900px]:items-center`. This aligns showing text, rows per page, and page indicators horizontally on screens >= 900px.
3. **No text removal on MD devices:**
   - Retained the `sm:inline` text classes (`Previous` / `Next`) for the navigation buttons, ensuring they display their text labels on medium devices (iPad Mini / 768px and up) while folding into compact icons on mobile.
4. **Clean Two-Row Separation:**
   - Split the pagination controls (Row 2) and metadata indicators (Row 1) into distinct blocks with a separating border. This centers the buttons row on all screens, keeping it fully visible without clipping.

## Related issues

- Closes #137 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [x] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open the Transactions page and scroll to the bottom of the table.
2. Verify visual rendering across the following screen widths:
   - **Under 340px:** Verify that the "Rows per page" and "Page X of Y" stack vertically, and the divider line `|` is hidden.
   - **iPad Mini (768px):** Verify that the buttons display the full "Previous" and "Next" text, and Row 1 is stacked into two centered lines to avoid horizontal overflow.
   - **900px to 1030px:** Verify that all metadata elements (Showing text, Rows per page dropdown, and Page status) are aligned side-by-side on a single row.
   - **Large Desktop (>= 1024px):** Verify Row 1 is aligned horizontally and Row 2 (the buttons) is centered beneath it.

## Media

https://github.com/user-attachments/assets/2bbd952b-fd5d-479b-a970-e139121848dd

- [x] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run build
```

## Build Output :
✓ 3024 modules transformed.
dist/index.html                     1.45 kB │ gzip:   0.63 kB
dist/assets/index-D5gUXb3V.css    135.47 kB │ gzip:  21.23 kB
dist/assets/index-xIM7kqZk.js   1,502.65 kB │ gzip: 437.34 kB
✓ built in 14.88s