### PR TITLE
fix(ui): Align settings tab spacing

### DIFF
--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,16 +1,18 @@
 import { Fragment, ReactNode } from "react";
+import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
   title?: string;
   subtitle?: string;
   rightAction?: ReactNode;
   renderPageHeader?: ReactNode;
+  className?: string;
 }
 
-const PageHeader = ({ title, subtitle, rightAction, renderPageHeader }: PageHeaderProps) => {
+const PageHeader = ({ title, subtitle, rightAction, renderPageHeader, className }: PageHeaderProps) => {
   return (
     <div className="w-full pb-20 pt-4 bg-[var(--secondary-dark-color)] text-white">
-      <div className="w-full max-w-[var(--max-width)] mx-auto px-4 sm:px-6">
+      <div className={cn("w-full max-w-[var(--max-width)] mx-auto px-4 sm:px-6", className)}>
         {renderPageHeader ? (
           <Fragment>{renderPageHeader}</Fragment>
         ) : (

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -3,16 +3,17 @@ import PageHeader from "./page-header";
 
 interface PropsType {
   children: React.ReactNode;
-  className?: string
+  className?: string;
+  headerClassName?: string;
   title?: string;
   subtitle?: string;
   rightAction?: React.ReactNode;
   showHeader?: boolean;
   addMarginTop?: boolean;
-  renderPageHeader?: React.ReactNode
+  renderPageHeader?: React.ReactNode;
 }
 
-const PageLayout = ({ children, className,
+const PageLayout = ({ children, className, headerClassName,
   title,
   subtitle,
   rightAction,
@@ -23,11 +24,12 @@ const PageLayout = ({ children, className,
   return (
     <div>
       {showHeader && (
-        <PageHeader 
-          title={title} 
-          subtitle={subtitle} 
-          rightAction={rightAction} 
+        <PageHeader
+          title={title}
+          subtitle={subtitle}
+          rightAction={rightAction}
           renderPageHeader={renderPageHeader}
+          className={headerClassName}
         />
       )}
     <div className={cn("w-full max-w-[var(--max-width)] mx-auto px-4 sm:px-6 pt-8",

--- a/src/layouts/app-layout.tsx
+++ b/src/layouts/app-layout.tsx
@@ -22,6 +22,7 @@ const AppLayout = () => {
 
         {/* Right Side: Header and Main Content Page Area */}
         <div
+          data-sidebar={sidebarCollapsed ? "collapsed" : "expanded"}
           className={cn(
             "flex-1 flex flex-col min-h-screen w-full transition-all duration-300",
             sidebarCollapsed ? "md:pl-16" : "md:pl-64"

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -23,6 +23,8 @@ const Settings = () => {
       title="Settings"
       subtitle="Manage your account settings and set e-mail preferences."
       addMarginTop
+      className="md:mx-3 md:in-data-[sidebar=collapsed]:mx-auto"
+      headerClassName="md:mx-4 md:in-data-[sidebar=collapsed]:mx-auto"
     >
       <Card className="border shadow-none">
         <CardContent>


### PR DESCRIPTION
## Summary

Fix horizontal layout shift in the Settings page when switching between tabs that trigger a scrollbar (Account, Appearance) and tabs that don't (Security).
Root cause: When a vertical scrollbar appears/disappears, the browser recalculates mx-auto centering on the PageHeader and PageLayout inner containers, shifting content horizontally

## Related issues

- Closes  #144


## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open the Settings page with the sidebar expanded
2. Switch between Account/Appearance and Security — content should not shift horizontally

## Media

- [x] I attached screenshots or recordings for visual changes.
- [ ] I linked the issue or discussion that motivated this change.

## Validation output

Paste command outputs:

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings

[Attach screenshots for UI-related changes.](https://github.com/user-attachments/assets/c408642e-da0b-4a73-b8c2-a99197a829d9)

## Breaking changes

- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [x] I added or updated tests where needed.
- [x] I updated documentation where needed.
- [x] I removed secrets and sensitive information.




