### PR TITLE
fix(auth): Prevent automatic user logout by refreshing access token before expiry

### DIFF
--- a/src/features/auth/authAPI.ts
+++ b/src/features/auth/authAPI.ts
@@ -9,6 +9,7 @@ import type {
   ResetPasswordResponse,
   VerifyOtpRequest,
   VerifyOtpResponse,
+  RefreshTokenResponse
 } from "./authType";
 
 export const authApi = apiClient.injectEndpoints({
@@ -63,10 +64,11 @@ export const authApi = apiClient.injectEndpoints({
         method: "POST",
       }),
     }),
-    refresh: builder.mutation({
-      query: () => ({
+    refresh: builder.mutation<RefreshTokenResponse,{refreshToken:string}>({
+      query: (body) => ({
         url: "/auth/refresh-token",
         method: "POST",
+        body
       }),
     }),
   }),

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 
 interface AuthState {
   accessToken: string | null;
+  refreshToken: string | null;
   expiresAt: number | null;
   user: User | null;
   reportSetting: ReportSetting | null;
@@ -24,6 +25,7 @@ interface ReportSetting {
 
 const initialState: AuthState = {
   accessToken: null,
+  refreshToken: null,
   expiresAt: null,
   user: null,
   reportSetting: null,
@@ -35,14 +37,16 @@ const authSlice = createSlice({
   reducers: {
     setCredentials: (state, action) => {
       state.accessToken = action.payload.accessToken;
+      state.refreshToken = action.payload.refreshToken || null;
       state.expiresAt = action.payload.expiresAt;
       state.user = action.payload.user;
       state.reportSetting = action.payload.reportSetting;
     },
     updateCredentials: (state, action) => {
-      const { accessToken, expiresAt, user, reportSetting } = action.payload;
+      const { accessToken, refreshToken, expiresAt, user, reportSetting } = action.payload;
 
       if (accessToken !== undefined) state.accessToken = accessToken;
+      if (refreshToken !== undefined) state.refreshToken = refreshToken;
       if (expiresAt !== undefined) state.expiresAt = expiresAt;
       if (user !== undefined) state.user = { ...state.user, ...user };
       if (reportSetting !== undefined)
@@ -50,6 +54,7 @@ const authSlice = createSlice({
     },
     logout: (state) => {
       state.accessToken = null;
+      state.refreshToken = null;
       state.expiresAt = null;
       state.user = null;
       state.reportSetting = null;

--- a/src/features/auth/authType.ts
+++ b/src/features/auth/authType.ts
@@ -25,6 +25,7 @@ export interface LoginResponse {
 	message?: string;
 	user: AuthUser;
 	accessToken: string;
+	refreshToken?: string;
 	expiresAt: number;
 	reportSetting: AuthReportSetting | null;
 }
@@ -43,6 +44,7 @@ export interface VerifyOtpResponse {
 	data: {
 		user: AuthUser;
 		accessToken: string;
+		refreshToken?: string;
 		expiresAt: number;
 		reportSetting: AuthReportSetting | null;
 		verified: boolean;
@@ -72,4 +74,10 @@ export interface ErrorResponse {
 		message?: string;
 		errorCode?: string;
 	};
+}
+
+export interface RefreshTokenResponse {
+	accessToken: string;
+	expiresAt: number;
+	refreshToken?: string;
 }

--- a/src/hooks/use-auth-expiration.ts
+++ b/src/hooks/use-auth-expiration.ts
@@ -24,13 +24,6 @@ const useAuthExpiration = () => {
         const { accessToken, expiresAt, refreshToken: newRefreshToken } = await refreshToken({
           refreshToken: storedRefreshToken
         }).unwrap();
-
-        console.log("✅ Token refreshed successfully");
-        console.log({
-          accessToken,
-          expiresAt,
-          refreshToken: newRefreshToken,
-        });
         dispatch(updateCredentials({ accessToken, expiresAt, refreshToken: newRefreshToken || storedRefreshToken }));
 
 

--- a/src/hooks/use-auth-expiration.ts
+++ b/src/hooks/use-auth-expiration.ts
@@ -4,21 +4,36 @@ import { logout, updateCredentials } from "@/features/auth/authSlice";
 import { useRefreshMutation } from "@/features/auth/authAPI";
 
 const useAuthExpiration = () => {
-  const { accessToken, expiresAt } = useTypedSelector((state) => state.auth);
+  const { accessToken, expiresAt, refreshToken: storedRefreshToken } = useTypedSelector((state) => state.auth);
   const dispatch = useAppDispatch();
   const [refreshToken] = useRefreshMutation();
 
   useEffect(() => {
     const handleLogout = () => {
-      
+
       dispatch(logout());
     };
 
     const handleTokenRefresh = async () => {
       try {
-        const { accessToken, expiresAt } = await refreshToken({}).unwrap();
-        dispatch(updateCredentials({ accessToken, expiresAt }));
-        
+
+        if (!storedRefreshToken) {
+          throw new Error("No refresh token stored");
+        }
+
+        const { accessToken, expiresAt, refreshToken: newRefreshToken } = await refreshToken({
+          refreshToken: storedRefreshToken
+        }).unwrap();
+
+        console.log("✅ Token refreshed successfully");
+        console.log({
+          accessToken,
+          expiresAt,
+          refreshToken: newRefreshToken,
+        });
+        dispatch(updateCredentials({ accessToken, expiresAt, refreshToken: newRefreshToken || storedRefreshToken }));
+
+
       } catch (error) {
         console.error("Token refresh failed, logging out...", error);
         handleLogout();
@@ -28,17 +43,21 @@ const useAuthExpiration = () => {
     if (accessToken && expiresAt) {
       const currentTime = Date.now();
       const timeUntilExpiration = expiresAt - currentTime;
-      if (timeUntilExpiration <= 0) {
-        // Token is already expired
+
+      // Refresh slightly BEFORE it expires
+      const bufferTime = 60 * 1000;
+
+      if (timeUntilExpiration <= bufferTime) {
+        // Token is already expired or very close to expiring
         handleTokenRefresh();
       } else {
-        // Set a timeout to log out the user when the token expires
-        const timer = setTimeout(handleLogout, timeUntilExpiration);
+        // Set a timeout to REFRESH the token right before it expires
+        const timer = setTimeout(handleTokenRefresh, timeUntilExpiration - bufferTime);
         // Cleanup the timer on component unmount or token change
         return () => clearTimeout(timer);
       }
     }
-  }, [accessToken, dispatch, expiresAt, refreshToken]);
+  }, [accessToken, dispatch, expiresAt, refreshToken, storedRefreshToken]);
 };
 
 export default useAuthExpiration;


### PR DESCRIPTION
## Summary

Replaced the logout timer in `useAuthExpiration()` with a proactive refresh 
timer that fires 60 seconds before token expiry. The user session is now 
silently refreshed in the background instead of being terminated. Logout 
only occurs if the refresh API call itself fails.

## Related issues


-  Closes #155

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] ui (components / pages)
- [ ] design (tokens / styles)
- [x] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Log in to the application.
2. Shorten the `expiresAt` value in Redux auth state to ~70 seconds from now.
3. Wait 10 seconds.
4. Observe that a refresh request is made automatically in the Network tab.
5. Confirm the user remains logged in after the original expiry time passes.
6. To test fallback: mock the refresh endpoint to return a 401 and confirm 
   the user is logged out gracefully.

## Media

- [ ] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

Paste command outputs:

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings

N/A — not a visual change.

## Breaking changes

- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
