### PR TITLE
fix(client): Remove duplicate hamburger and layout overlay

### DIFF
--- a/src/components/navbar/header-bar.tsx
+++ b/src/components/navbar/header-bar.tsx
@@ -1,11 +1,8 @@
-import { useState } from "react";
-import { Sun, Moon, Menu, PanelLeft } from "lucide-react";
+import { Sun, Moon, PanelLeft } from "lucide-react";
 import { useTypedSelector } from "@/app/hook";
 import { useTheme } from "@/context/theme-provider";
 import { Button } from "../ui/button";
-import { Sheet, SheetContent } from "../ui/sheet";
 import { UserNav } from "./user-nav";
-import Sidebar from "../sidebar";
 import Logo from "../logo/logo";
 import { NotificationDropdown } from "./notification-dropdown";
 
@@ -18,26 +15,15 @@ interface HeaderBarProps {
 export const HeaderBar = ({ onLogoutClick, sidebarCollapsed, onSidebarToggle }: HeaderBarProps) => {
   const { user } = useTypedSelector((state) => state.auth);
   const { theme, setTheme } = useTheme();
-  const [isMobileDrawerOpen, setIsMobileDrawerOpen] = useState(false);
 
   return (
     <>
       <header className="sticky top-0 z-30 flex h-14 sm:h-16 w-full items-center justify-between border-b border-zinc-150/70 dark:border-white/5 bg-background/80 px-3 sm:px-6 backdrop-blur-lg transition-all duration-300">
 
-        {/* Left Side: Mobile Hamburger + Brand, Desktop Sidebar Toggle */}
+        {/* Left Side: Mobile Brand Logo, Desktop Sidebar Toggle */}
         <div className="flex items-center gap-2 sm:gap-3">
-          {/* Mobile hamburger menu */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="inline-flex md:hidden text-foreground hover:bg-muted/65 border border-transparent hover:border-border/30 rounded-xl h-8 w-8 sm:h-9 sm:w-9"
-            onClick={() => setIsMobileDrawerOpen(true)}
-          >
-            <Menu className="h-4 w-4 sm:h-5 sm:w-5" />
-          </Button>
-
-          {/* Mobile Brand Logo — icon only on xs, full on sm */}
-          <div className="flex md:hidden text-foreground [&_span]:text-foreground [&_img]:opacity-95">
+          {/* Mobile Brand Logo (with spacing to account for floating sidebar button on the very left) */}
+          <div className="flex md:hidden text-foreground [&_span]:text-foreground [&_img]:opacity-95 pl-10 sm:pl-12">
             <div className="sm:hidden"><Logo compact /></div>
             <div className="hidden sm:flex"><Logo /></div>
           </div>
@@ -86,16 +72,6 @@ export const HeaderBar = ({ onLogoutClick, sidebarCollapsed, onSidebarToggle }: 
           />
         </div>
       </header>
-
-      {/* Mobile Drawer Sheet Overlay */}
-      <Sheet open={isMobileDrawerOpen} onOpenChange={setIsMobileDrawerOpen}>
-        <SheetContent side="left" className="p-0 border-r border-zinc-150/70 dark:border-white/5 w-64 bg-transparent">
-          <Sidebar
-            className="fixed top-0 bottom-0 left-0 right-0 h-full w-full bg-white dark:bg-zinc-950/95"
-            onLinkClick={() => setIsMobileDrawerOpen(false)}
-          />
-        </SheetContent>
-      </Sheet>
     </>
   );
 };

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -43,124 +43,127 @@ const Sidebar = ({ className, onLinkClick, collapsed = false }: SidebarProps) =>
     onLinkClick?.();
   };
 
-  // Sidebar content component to avoid duplication
-  const SidebarContent = () => (
-    <>
-      <div className="flex flex-col flex-1">
-        <div className="flex flex-col gap-8">
-          {/* Logo */}
-          <div className={cn("transition-all duration-300", collapsed ? "flex justify-center" : "px-3")}>
-            {collapsed ? (
-              <img src="/logo.png" alt="VoiceyBill" className="h-8 w-8 rounded-lg object-cover flex-shrink-0" />
-            ) : (
-              <NavLink to={PROTECTED_ROUTES.OVERVIEW} className="flex items-center gap-2.5" onClick={handleLinkClick}>
-                <img src="/logo.png" alt="VoiceyBill" className="h-8 w-8 flex-shrink-0 rounded-lg object-cover" />
-                <span className="font-semibold text-[17px] tracking-tight whitespace-nowrap">VoiceyBill</span>
-              </NavLink>
-            )}
+  // Sidebar content component with a parameter to force expand on mobile
+  const SidebarContent = ({ forceExpand = false }: { forceExpand?: boolean }) => {
+    const isCollapsed = forceExpand ? false : collapsed;
+    return (
+      <>
+        <div className="flex flex-col flex-1">
+          <div className="flex flex-col gap-8">
+            {/* Logo */}
+            <div className={cn("transition-all duration-300", isCollapsed ? "flex justify-center" : "px-3")}>
+              {isCollapsed ? (
+                <img src="/logo.png" alt="VoiceyBill" className="h-8 w-8 rounded-lg object-cover flex-shrink-0" />
+              ) : (
+                <NavLink to={PROTECTED_ROUTES.OVERVIEW} className="flex items-center gap-2.5" onClick={handleLinkClick}>
+                  <img src="/logo.png" alt="VoiceyBill" className="h-8 w-8 flex-shrink-0 rounded-lg object-cover" />
+                  <span className="font-semibold text-[17px] tracking-tight whitespace-nowrap">VoiceyBill</span>
+                </NavLink>
+              )}
+            </div>
+
+            {/* Navigation Links */}
+            <nav className="flex flex-col gap-1.5">
+              {routes.map((route) => {
+                const Icon = route.Icon;
+                const isActive = pathname === route.href;
+                return (
+                  <Button
+                    key={route.href}
+                    size="sm"
+                    variant="ghost"
+                    className={cn(
+                      "w-full font-semibold text-[13.5px] rounded-full border border-transparent transition-all duration-300 group",
+                      isCollapsed ? "justify-center px-0 py-2.5" : "justify-start gap-3.5 px-4 py-2.5",
+                      isActive
+                        ? "text-primary bg-primary/8 border-primary/20 dark:text-brand-green-light dark:bg-brand-green-light/8 dark:border-brand-green-light/10 shadow-[0_2px_12px_-4px_rgba(22,97,20,0.06)] dark:shadow-[0_2px_12px_-4px_rgba(159,255,89,0.06)]"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                    )}
+                    asChild
+                  >
+                    <NavLink to={route.href} onClick={handleLinkClick} title={isCollapsed ? route.label : undefined}>
+                      <Icon
+                        className={cn(
+                          "h-[17px] w-[17px] shrink-0 transition-transform duration-300 group-hover:scale-110",
+                          isActive
+                            ? "text-primary dark:text-brand-green-light"
+                            : "text-muted-foreground group-hover:text-foreground"
+                        )}
+                      />
+                      {!isCollapsed && <span>{route.label}</span>}
+                    </NavLink>
+                  </Button>
+                );
+              })}
+            </nav>
           </div>
-
-          {/* Navigation Links */}
-          <nav className="flex flex-col gap-1.5">
-            {routes.map((route) => {
-              const Icon = route.Icon;
-              const isActive = pathname === route.href;
-              return (
-                <Button
-                  key={route.href}
-                  size="sm"
-                  variant="ghost"
-                  className={cn(
-                    "w-full font-semibold text-[13.5px] rounded-full border border-transparent transition-all duration-300 group",
-                    collapsed ? "justify-center px-0 py-2.5" : "justify-start gap-3.5 px-4 py-2.5",
-                    isActive
-                      ? "text-primary bg-primary/8 border-primary/20 dark:text-brand-green-light dark:bg-brand-green-light/8 dark:border-brand-green-light/10 shadow-[0_2px_12px_-4px_rgba(22,97,20,0.06)] dark:shadow-[0_2px_12px_-4px_rgba(159,255,89,0.06)]"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                  )}
-                  asChild
-                >
-                  <NavLink to={route.href} onClick={handleLinkClick} title={collapsed ? route.label : undefined}>
-                    <Icon
-                      className={cn(
-                        "h-[17px] w-[17px] shrink-0 transition-transform duration-300 group-hover:scale-110",
-                        isActive
-                          ? "text-primary dark:text-brand-green-light"
-                          : "text-muted-foreground group-hover:text-foreground"
-                      )}
-                    />
-                    {!collapsed && <span>{route.label}</span>}
-                  </NavLink>
-                </Button>
-              );
-            })}
-          </nav>
         </div>
-      </div>
 
-      {/* Bottom section */}
-      <div className="flex flex-col gap-4 mt-auto">
-        {/* VoiceyAI Promo Card — hidden when collapsed */}
-        {!collapsed && (
-          <div className="relative overflow-hidden p-4 rounded-2xl border border-zinc-150/80 dark:border-white/5 bg-zinc-50/50 dark:bg-white/[0.01] backdrop-blur-md shadow-sm group">
-            <div className="absolute -right-8 -bottom-8 w-24 h-24 rounded-full bg-brand-green/5 dark:bg-brand-green-light/3 blur-xl group-hover:scale-125 transition-all duration-500 pointer-events-none" />
-            <div className="flex items-start gap-2.5 z-10 relative">
-              <div className="h-7 w-7 rounded-lg bg-primary/8 dark:bg-brand-green-light/8 flex items-center justify-center text-primary dark:text-brand-green-light">
-                <Sparkles className="h-3.5 w-3.5" />
+        {/* Bottom section */}
+        <div className="flex flex-col gap-4 mt-auto">
+          {/* VoiceyAI Promo Card — hidden when collapsed */}
+          {!isCollapsed && (
+            <div className="relative overflow-hidden p-4 rounded-2xl border border-zinc-150/80 dark:border-white/5 bg-zinc-50/50 dark:bg-white/[0.01] backdrop-blur-md shadow-sm group">
+              <div className="absolute -right-8 -bottom-8 w-24 h-24 rounded-full bg-brand-green/5 dark:bg-brand-green-light/3 blur-xl group-hover:scale-125 transition-all duration-500 pointer-events-none" />
+              <div className="flex items-start gap-2.5 z-10 relative">
+                <div className="h-7 w-7 rounded-lg bg-primary/8 dark:bg-brand-green-light/8 flex items-center justify-center text-primary dark:text-brand-green-light">
+                  <Sparkles className="h-3.5 w-3.5" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-[11.5px] font-extrabold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">
+                    VoiceyAI Input
+                  </p>
+                  <p className="text-[10.5px] text-muted-foreground mt-0.5 leading-relaxed font-medium">
+                    Add transactions seamlessly using your voice!
+                  </p>
+                </div>
               </div>
-              <div className="flex-1">
-                <p className="text-[11.5px] font-extrabold uppercase tracking-wider text-zinc-700 dark:text-zinc-300">
-                  VoiceyAI Input
-                </p>
-                <p className="text-[10.5px] text-muted-foreground mt-0.5 leading-relaxed font-medium">
-                  Add transactions seamlessly using your voice!
-                </p>
+              <div className="mt-3.5 flex items-center justify-between bg-white dark:bg-zinc-900/50 border border-zinc-150/50 dark:border-white/5 p-2 rounded-xl">
+                <span className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest pl-1.5">
+                  READY TO RECORD
+                </span>
+                <div
+                  className="h-7 w-7 rounded-full bg-brand-green dark:bg-brand-green-light flex items-center justify-center shadow-md dark:shadow-brand-green-light/10 text-white dark:text-zinc-950 animate-voice-pulse hover:scale-105 transition-all duration-300 cursor-pointer"
+                  onClick={() => onOpenDrawer("voice")}
+                >
+                  <Mic className="h-3.5 w-3.5" />
+                </div>
               </div>
             </div>
-            <div className="mt-3.5 flex items-center justify-between bg-white dark:bg-zinc-900/50 border border-zinc-150/50 dark:border-white/5 p-2 rounded-xl">
-              <span className="text-[10px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest pl-1.5">
-                READY TO RECORD
-              </span>
+          )}
+
+          {/* Mic icon only when collapsed */}
+          {isCollapsed && (
+            <div className="flex justify-center">
               <div
-                className="h-7 w-7 rounded-full bg-brand-green dark:bg-brand-green-light flex items-center justify-center shadow-md dark:shadow-brand-green-light/10 text-white dark:text-zinc-950 animate-voice-pulse hover:scale-105 transition-all duration-300 cursor-pointer"
+                className="h-8 w-8 rounded-full bg-brand-green dark:bg-brand-green-light flex items-center justify-center shadow-md text-white dark:text-zinc-950 animate-voice-pulse hover:scale-105 transition-all duration-300 cursor-pointer"
                 onClick={() => onOpenDrawer("voice")}
+                title="Add transaction by voice"
               >
                 <Mic className="h-3.5 w-3.5" />
               </div>
             </div>
-          </div>
-        )}
-
-        {/* Mic icon only when collapsed */}
-        {collapsed && (
-          <div className="flex justify-center">
-            <div
-              className="h-8 w-8 rounded-full bg-brand-green dark:bg-brand-green-light flex items-center justify-center shadow-md text-white dark:text-zinc-950 animate-voice-pulse hover:scale-105 transition-all duration-300 cursor-pointer"
-              onClick={() => onOpenDrawer("voice")}
-              title="Add transaction by voice"
-            >
-              <Mic className="h-3.5 w-3.5" />
-            </div>
-          </div>
-        )}
-
-        <div className="h-px bg-zinc-150/60 dark:bg-white/5 w-full" />
-
-        {/* Logout */}
-        <Button
-          size="sm"
-          variant="ghost"
-          className={cn(
-            "w-full font-semibold text-[13.5px] text-rose-600 hover:text-rose-700 hover:bg-rose-50 dark:text-rose-400 dark:hover:text-rose-350 dark:hover:bg-rose-950/10 rounded-full border border-transparent transition-all duration-200 group",
-            collapsed ? "justify-center px-0 py-2.5" : "justify-start gap-3.5 px-4 py-2.5"
           )}
-          onClick={() => setIsLogoutDialogOpen(true)}
-        >
-          <LogOut className="h-[17px] w-[17px] shrink-0 text-rose-500 dark:text-rose-450 transition-transform duration-300 group-hover:-translate-x-0.5" />
-          {!collapsed && <span>Log Out</span>}
-        </Button>
-      </div>
-    </>
-  );
+
+          <div className="h-px bg-zinc-150/60 dark:bg-white/5 w-full" />
+
+          {/* Logout */}
+          <Button
+            size="sm"
+            variant="ghost"
+            className={cn(
+              "w-full font-semibold text-[13.5px] text-rose-600 hover:text-rose-700 hover:bg-rose-50 dark:text-rose-400 dark:hover:text-rose-350 dark:hover:bg-rose-950/10 rounded-full border border-transparent transition-all duration-200 group",
+              isCollapsed ? "justify-center px-0 py-2.5" : "justify-start gap-3.5 px-4 py-2.5"
+            )}
+            onClick={() => setIsLogoutDialogOpen(true)}
+          >
+            <LogOut className="h-[17px] w-[17px] shrink-0 text-rose-500 dark:text-rose-450 transition-transform duration-300 group-hover:-translate-x-0.5" />
+            {!isCollapsed && <span>Log Out</span>}
+          </Button>
+        </div>
+      </>
+    );
+  };
 
   return (
     <>
@@ -199,23 +202,23 @@ const Sidebar = ({ className, onLinkClick, collapsed = false }: SidebarProps) =>
           onClick={() => setIsMobileOpen(false)}
         />
 
-        {/* Mobile Sidebar Panel */}
+        {/* Mobile Sidebar Panel - ALWAYS force expand to w-64 */}
         <aside
           className={cn(
-            "absolute left-0 top-0 h-screen bg-white/95 dark:bg-zinc-950/95 border-r border-zinc-150/70 dark:border-white/5 py-6 backdrop-blur-xl transition-all duration-300 flex flex-col justify-between overflow-y-auto",
-            isMobileOpen ? "translate-x-0" : "-translate-x-full",
-            collapsed ? "w-16 px-2" : "w-64 px-4"
+            "absolute left-0 top-0 h-screen bg-white/95 dark:bg-zinc-950/95 border-r border-zinc-150/70 dark:border-white/5 py-6 backdrop-blur-xl transition-all duration-300 flex flex-col justify-between overflow-y-auto w-64 px-4",
+            isMobileOpen ? "translate-x-0" : "-translate-x-full"
           )}
         >
-          {/* Close Button */}
+          {/* Close Button - elevated z-index and high contrast colors */}
           <button
             onClick={() => setIsMobileOpen(false)}
-            className="absolute top-6 right-4 p-1 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors z-10"
+            className="absolute top-6 right-4 p-1.5 rounded-lg text-zinc-500 hover:text-zinc-850 dark:text-zinc-400 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-900 transition-colors z-50"
+            aria-label="Close menu"
           >
             <X className="h-5 w-5" />
           </button>
 
-          <SidebarContent />
+          <SidebarContent forceExpand={true} />
         </aside>
       </div>
 


### PR DESCRIPTION
## Summary

This PR resolves the duplicate mobile hamburger menu issue in the client application:
1. Removed duplicate mobile menu button and Sheet wrapper from HeaderBar.
2. Restructured Sidebar's self-contained mobile panel drawer to lock to w-64 width, ensuring it never collapses on mobile.
3. Styled the Close (X) button with high contrast colors and z-50 to make it fully visible and clickable.

## Related issues

- Closes #181 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] backend
- [x] client (web)
- [ ] mobile (React Native)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open the app on mobile viewport.
2. Verify that there is only one hamburger menu button at the top-left of the viewport.
3. Click the button to open the mobile sidebar drawer.

## Media

- [ ] I attached screenshots or recordings for visual changes.
- [ ] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run build
```

## Output :

✓ 3026 modules transformed.
dist/index.html                     1.45 kB │ gzip:   0.62 kB  
dist/assets/index-27kcJUH9.css    138.14 kB │ gzip:  21.67 kB  
dist/assets/index-CaimzUjj.js   1,516.89 kB │ gzip: 443.12 kB  

## Screenshots or recordings

**Hamburger :**
<img width="547" height="165" alt="image" src="https://github.com/user-attachments/assets/11afc00a-106c-45f7-80cd-a5cf3195b550" />

**Sidebar :**
<img width="547" height="419" alt="image" src="https://github.com/user-attachments/assets/6f0bb83d-01b3-4607-95c7-0186290fb0d4" />


## Breaking changes
- [x] No
- [ ] Yes (describe below)

## Checklist
- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.
