### PR TITLE
fix(ui): Resolve WCAG 2.1 Accessibility Violations on Dashboard Overview Page

### DIFF
--- a/src/components/date-range-select/index.tsx
+++ b/src/components/date-range-select/index.tsx
@@ -158,6 +158,7 @@ export const DateRangeSelect = ({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
+          aria-label={`Select date range: ${displayText}`}
           className={cn(
             `w-[200px] flex items-center justify-between text-left font-normal !bg-[var(--secondary-dark-color)]
             border-gray-700 !text-white !cursor-pointer`,

--- a/src/components/navbar/header-bar.tsx
+++ b/src/components/navbar/header-bar.tsx
@@ -35,6 +35,7 @@ export const HeaderBar = ({ onLogoutClick, sidebarCollapsed, onSidebarToggle }: 
             className="hidden md:inline-flex h-9 w-9 rounded-xl text-muted-foreground hover:text-foreground hover:bg-muted/65 border border-transparent hover:border-border/30 transition-all duration-200"
             onClick={onSidebarToggle}
             title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           >
             <PanelLeft className="h-4 w-4" />
           </Button>
@@ -49,6 +50,7 @@ export const HeaderBar = ({ onLogoutClick, sidebarCollapsed, onSidebarToggle }: 
             className="h-8 w-8 sm:h-9 sm:w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted/65 border border-transparent hover:border-border/30 transition-all duration-200"
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
             title="Toggle Theme"
+            aria-label="Toggle theme"
           >
             {theme === "dark" ? (
               <Sun className="h-4 w-4 text-primary" />

--- a/src/components/navbar/notification-dropdown.tsx
+++ b/src/components/navbar/notification-dropdown.tsx
@@ -82,6 +82,7 @@ export const NotificationDropdown = () => {
         className="h-8 w-8 sm:h-9 sm:w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted/65 border border-transparent hover:border-border/30 transition-all duration-200"
         onClick={() => setIsOpen(!isOpen)}
         title="Notifications"
+        aria-label={unreadCount > 0 ? `Notifications (${unreadCount} unread)` : "Notifications"}
       >
         <Bell className="h-4 w-4" />
       </Button>
@@ -117,6 +118,7 @@ export const NotificationDropdown = () => {
                   size="icon"
                   className="h-6 w-6"
                   onClick={() => dispatch(clearNotifications())}
+                  aria-label="Clear all notifications"
                 >
                   <Trash2 className="h-3 w-3" />
                 </Button>
@@ -160,6 +162,7 @@ export const NotificationDropdown = () => {
                       variant="ghost"
                       size="icon"
                       className="h-5 w-5 shrink-0"
+                      aria-label="Remove notification"
                       onClick={(e) =>
                         handleRemoveNotification(e, notification.id)
                       }

--- a/src/components/navbar/user-nav.tsx
+++ b/src/components/navbar/user-nav.tsx
@@ -30,6 +30,7 @@ export function UserNav({
           <Avatar className="h-7 w-7 !cursor-pointer transition-transform duration-200 hover:scale-105">
             <AvatarImage
               src={profilePicture || ""}
+              alt={userName ? `${userName}'s profile picture` : "User profile picture"}
               className="!cursor-pointer"
             />
             <AvatarFallback

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -181,6 +181,7 @@ const Sidebar = ({ className, onLinkClick, collapsed = false }: SidebarProps) =>
       {/* Mobile Menu Button */}
       <button
         onClick={() => setIsMobileOpen(true)}
+        aria-label="Open navigation menu"
         className="fixed top-3 left-2 z-50 md:hidden p-2 rounded-lg bg-white/70 dark:bg-zinc-950/25 backdrop-blur-xl border border-zinc-150/70 dark:border-white/5"
       >
         <Menu className="h-5 w-5 text-foreground" />

--- a/src/components/transaction/transaction-table/column.tsx
+++ b/src/components/transaction/transaction-table/column.tsx
@@ -133,12 +133,15 @@ export const transactionColumns = (
     {
       id: "select",
       header: ({ table }) => (
-        <Checkbox
-          className="!border-[var(--surface-border)] data-[state=checked]:!bg-foreground !text-background"
-          checked={table.getIsAllPageRowsSelected()}
-          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-          aria-label="Select all"
-        />
+        <div className="flex items-center">
+          <Checkbox
+            className="!border-[var(--surface-border)] data-[state=checked]:!bg-foreground !text-background"
+            checked={table.getIsAllPageRowsSelected()}
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+            aria-label="Select all"
+          />
+          <span className="sr-only">Select all</span>
+        </div>
       ),
       cell: ({ row }) => (
         <Checkbox
@@ -335,6 +338,7 @@ export const transactionColumns = (
     },
     {
       id: "actions",
+      header: () => <span className="sr-only">Actions</span>,
       enableHiding: false,
       cell: ({ row }) => <ActionsCell row={row} />,
     },
@@ -381,7 +385,7 @@ const ActionsCell = ({ row }: { row: Row<TransactionType> }) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="h-8 w-8 p-0">
+        <Button variant="ghost" className="h-8 w-8 p-0" aria-label="Open actions menu">
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>

--- a/src/pages/reports/_component/column.tsx
+++ b/src/pages/reports/_component/column.tsx
@@ -116,6 +116,6 @@ export const reportColumns = ({
 
   {
     id: "-",
-    header: "",
+    header: () => <span className="sr-only">Spacer</span>,
   },
 ];


### PR DESCRIPTION
## Summary
Resolved 17 WCAG 2.1 accessibility violations on the Dashboard Overview Page identified by the WAVE Web Accessibility Evaluation Tool. The updates ensure full usability for screen readers and keyboard navigation.

Key modifications:
- **Missing Alt Text**: Added descriptive `alt` attribute to the profile picture `AvatarImage` inside the `UserNav` dropdown component (`src/components/navbar/user-nav.tsx`).
- **Missing Form Label**: Added `aria-label` to the `DateRangeSelect` popover trigger button (`src/components/date-range-select/index.tsx`) so that the current duration is clearly identified.
- **Empty Buttons**: Added descriptive `aria-label` attributes to the theme switcher, desktop/mobile sidebar toggle triggers, and the notification bell/clear/close buttons.
- **Empty Table Headers**: Added screen-reader helper elements (`<span className="sr-only">`) to the select checkbox and actions columns in the transaction table, and the spacer column in the reports table.

## Related issues

- Closes #176 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Run the server and frontend web app locally.
2. Log in and navigate to the Dashboard Overview page.
3. Open the WAVE Web Accessibility Evaluation Tool browser extension.
4. Verify that the previous 17 errors are cleared and show aim score of 9.8 out of 10.

## Media
<img width="949" height="392" alt="Screenshot 2026-06-08 151142" src="https://github.com/user-attachments/assets/4415bf68-0938-4edd-9926-2d4eb2a37371" />

- [x] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run build

Output :
✓ 3027 modules transformed.
dist/index.html                     1.45 kB │ gzip:   0.63 kB
dist/assets/index-CJIifvZn.css    138.30 kB │ gzip:  21.69 kB
dist/assets/index-CG_LuZCJ.js   1,518.80 kB │ gzip: 443.71 kB
```
