### PR TITLE
fix: Budget card formatting and over-budget transition.

### DIFF
--- a/src/pages/budget/index.tsx
+++ b/src/pages/budget/index.tsx
@@ -429,40 +429,48 @@ export default function Budget() {
 
 
   const formatCurrency = useCallback(
-    (amount: number) =>
-      `${currencySymbol}${new Intl.NumberFormat("en-US").format(amount)}`,
+    (amount: number) => {
+      const isNegative = amount < 0;
+      const formatted = new Intl.NumberFormat("en-US").format(Math.abs(amount));
+      return isNegative ? `-${currencySymbol}${formatted}` : `${currencySymbol}${formatted}`;
+    },
     [currencySymbol]
   );
 
   const summaryItems = useMemo(
-    () => [
-      {
-        label: "Total Budget",
-        value: formatCurrency(budget?.totalBudget || 0),
-        progress: budget?.hasBudget ? 100 : 0,
-        tone: "safe" as const,
-      },
-      {
-        label: "Spent",
-        value: formatCurrency(budget?.spent || 0),
-        progress: budget?.usagePercentage || 0,
-        tone: getBudgetTone(budget?.usagePercentage || 0),
-      },
-      {
-        label: "Remaining",
-        value: formatCurrency(budget?.remaining || 0),
-        progress: budget?.hasBudget ? Math.max(100 - budget.usagePercentage, 0) : 0,
-        tone: getBudgetTone(budget?.usagePercentage || 0),
-      },
-      {
-        label: "Usage",
-        value: formatPercentage(budget?.usagePercentage || 0, {
-          decimalPlaces: 1,
-        }),
-        progress: budget?.usagePercentage || 0,
-        tone: getBudgetTone(budget?.usagePercentage || 0),
-      },
-    ],
+    () => {
+      const isOverBudget = (budget?.remaining ?? 0) < 0;
+      return [
+        {
+          label: "Total Budget",
+          value: formatCurrency(budget?.totalBudget || 0),
+          progress: budget?.hasBudget ? 100 : 0,
+          tone: "safe" as const,
+        },
+        {
+          label: "Spent",
+          value: formatCurrency(budget?.spent || 0),
+          progress: budget?.usagePercentage || 0,
+          tone: getBudgetTone(budget?.usagePercentage || 0),
+        },
+        {
+          label: isOverBudget ? "Over Budget" : "Remaining",
+          value: isOverBudget
+            ? formatCurrency(Math.abs(budget?.remaining || 0))
+            : formatCurrency(budget?.remaining || 0),
+          progress: budget?.hasBudget ? Math.max(100 - budget.usagePercentage, 0) : 0,
+          tone: isOverBudget ? ("critical" as const) : getBudgetTone(budget?.usagePercentage || 0),
+        },
+        {
+          label: "Usage",
+          value: formatPercentage(budget?.usagePercentage || 0, {
+            decimalPlaces: 1,
+          }),
+          progress: budget?.usagePercentage || 0,
+          tone: getBudgetTone(budget?.usagePercentage || 0),
+        },
+      ];
+    },
     [budget?.totalBudget, budget?.spent, budget?.remaining, budget?.usagePercentage, budget?.hasBudget, formatCurrency]
   );
 


### PR DESCRIPTION
## Summary

This PR resolves frontend visual bugs on the budget overview interface:
- **Negative Currency Formatter**: Fixed `formatCurrency` in `src/pages/budget/index.tsx` so negative balances correctly display the negative sign before the currency symbol (e.g., `-$2,000` instead of `$-2,000`).
- **Over Budget UI Transition**: Adjusted the `summaryItems` card configuration. When a budget is exceeded (`remaining < 0`), the card dynamically transitions to show the label **"Over Budget"** with the absolute exceeded value (e.g., `$2,000`) and highlights the progress indicator with a `critical` (red) tone.
- **Uncapped Usage Percentage Display**: Display the true percentage text (e.g., `10,100%`) when spending exceeds the limit, while keeping the visual progress bar capped at 100% width.

## Related issues

- Closes #189 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Set a monthly budget of `$200`.
2. Add transactions totaling `$300` (over-budget).
3. Navigate to the Budget page.
4. Verify the "Remaining" card updates its label to **"Over Budget"** in a red progress bar tone and displays the absolute overspent value `$100.00`.
5. Verify that any negative currency labels on the page format correctly (e.g., `-$100.00` instead of `$-100.00`).
6. Verify that the category text displays the true percentage (e.g. `150%` usage) when exceeded, while the visual bar behaves correctly.

## Media
<img width="948" height="412" alt="Screenshot 2026-06-08 152905" src="https://github.com/user-attachments/assets/137832a0-a5c2-4510-8f02-476caaa94166" />

## Budget Exceeded 
<img width="788" height="401" alt="image" src="https://github.com/user-attachments/assets/8e75d1be-5ca9-49f7-9e4b-f883aec90bc9" />

## Failing to add new transaction (specifically in groceries as it's budget and total both exxceeded)
<img width="951" height="415" alt="image" src="https://github.com/user-attachments/assets/498c2d1f-bbe4-442e-ba4a-4e33cb94d4bf" />


- [x] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run build

Output :
vite v6.3.6 building for production...
✓ 3027 modules transformed.
dist/index.html                     1.45 kB │ gzip:   0.62 kB
dist/assets/index-CJIifvZn.css    138.30 kB │ gzip:  21.69 kB
dist/assets/index-DXiSBzWf.js   1,518.97 kB │ gzip: 443.78 kB
```