### PR TITLE
fix: Budget page month selector theme and category list visibility

### DIFF
--- a/src/pages/budget/index.tsx
+++ b/src/pages/budget/index.tsx
@@ -150,133 +150,145 @@ function BudgetCategoryDistribution({
           </p>
         </div>
 
-        {chartData.length === 0 ? (
+        {categoryData.length === 0 ? (
           <div className="flex min-h-[260px] flex-col items-center justify-center px-6 py-10 text-center">
             <div className="mb-4 rounded-full bg-muted p-4">
               <WalletCards className="h-8 w-8 text-muted-foreground" />
             </div>
             <h4 className="text-sm font-semibold text-foreground">
-              No category spending yet
+              No category limits set yet
             </h4>
             <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-              Category distribution will appear when expenses are recorded.
+              Define category limits in your budget to track category-specific spending.
             </p>
           </div>
         ) : (
           <div className="grid gap-6 p-5 lg:grid-cols-[minmax(300px,0.95fr)_minmax(360px,1.25fr)]">
             <div className="min-w-0">
-              <ChartContainer
-                config={chartConfig}
-                className="mx-auto aspect-square h-[280px] max-h-[280px] w-full"
-              >
-                <PieChart>
-                  <ChartTooltip
-                    cursor={false}
-                    content={
-                      <ChartTooltipContent
-                        className="rounded-xl border border-border bg-card p-2.5 shadow-lg"
-                        hideLabel
-                        formatter={(_, __, item) => {
-                          const payload =
-                            item.payload as (typeof categoryData)[number];
-
-                          return (
-                            <div className="grid gap-1">
-                              <div className="flex items-center gap-2 font-semibold text-foreground">
-                                <span
-                                  className="h-2.5 w-2.5 rounded-full"
-                                  style={{ backgroundColor: payload.fill }}
-                                />
-                                {payload.label}
-                              </div>
-                              <div className="text-muted-foreground">
-                                {formatCurrency(payload.spent)} /{" "}
-                                {formatCurrency(payload.limit)}
-                              </div>
-                              <div
-                                className={
-                                  payload.exceeded
-                                    ? "font-medium text-red-600"
-                                    : "text-muted-foreground"
-                                }
-                              >
-                                {Math.round(payload.usagePercentage)}% usage,{" "}
-                                {payload.sharePercentage}% of spending
-                              </div>
-                            </div>
-                          );
-                        }}
-                      />
-                    }
-                  />
-                  <Pie
-                    data={chartData}
-                    dataKey="spent"
-                    nameKey="label"
-                    innerRadius={72}
-                    outerRadius={98}
-                    paddingAngle={2}
-                    stroke="transparent"
-                    strokeWidth={0}
+              {chartData.length === 0 ? (
+                <div className="flex aspect-square h-[280px] max-h-[280px] w-full flex-col items-center justify-center border border-dashed border-border rounded-xl text-center p-6">
+                  <WalletCards className="h-8 w-8 text-muted-foreground mb-2" />
+                  <p className="text-sm font-semibold text-foreground">No category spending yet</p>
+                  <p className="text-xs text-muted-foreground mt-1 max-w-[200px]">
+                    Category distribution will appear here once expenses are recorded.
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <ChartContainer
+                    config={chartConfig}
+                    className="mx-auto aspect-square h-[280px] max-h-[280px] w-full"
                   >
-                    {chartData.map((category) => (
-                      <Cell key={category.name} fill={category.fill} />
-                    ))}
-                    <Label
-                      content={({ viewBox }) => {
-                        if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                          const cx = viewBox.cx ?? 0;
-                          const cy = viewBox.cy ?? 0;
+                    <PieChart>
+                      <ChartTooltip
+                        cursor={false}
+                        content={
+                          <ChartTooltipContent
+                            className="rounded-xl border border-border bg-card p-2.5 shadow-lg"
+                            hideLabel
+                            formatter={(_, __, item) => {
+                              const payload =
+                                item.payload as (typeof categoryData)[number];
 
-                          return (
-                            <text
-                              x={cx}
-                              y={cy}
-                              textAnchor="middle"
-                              dominantBaseline="middle"
-                            >
-                              <tspan
-                                x={cx}
-                                y={cy - 4}
-                                className="fill-foreground text-2xl font-bold"
-                              >
-                                {formatCurrency(totalSpent)}
-                              </tspan>
-                              <tspan
-                                x={cx}
-                                y={cy + 18}
-                                className="fill-muted-foreground text-xs font-medium"
-                              >
-                                Total Spent
-                              </tspan>
-                            </text>
-                          );
+                              return (
+                                <div className="grid gap-1">
+                                  <div className="flex items-center gap-2 font-semibold text-foreground">
+                                    <span
+                                      className="h-2.5 w-2.5 rounded-full"
+                                      style={{ backgroundColor: payload.fill }}
+                                    />
+                                    {payload.label}
+                                  </div>
+                                  <div className="text-muted-foreground">
+                                    {formatCurrency(payload.spent)} /{" "}
+                                    {formatCurrency(payload.limit)}
+                                  </div>
+                                  <div
+                                    className={
+                                      payload.exceeded
+                                        ? "font-medium text-red-600"
+                                        : "text-muted-foreground"
+                                    }
+                                  >
+                                    {Math.round(payload.usagePercentage)}% usage,{" "}
+                                    {payload.sharePercentage}% of spending
+                                  </div>
+                                </div>
+                              );
+                            }}
+                          />
                         }
-                      }}
-                    />
-                  </Pie>
-                </PieChart>
-              </ChartContainer>
+                      />
+                      <Pie
+                        data={chartData}
+                        dataKey="spent"
+                        nameKey="label"
+                        innerRadius={72}
+                        outerRadius={98}
+                        paddingAngle={2}
+                        stroke="transparent"
+                        strokeWidth={0}
+                      >
+                        {chartData.map((category) => (
+                          <Cell key={category.name} fill={category.fill} />
+                        ))}
+                        <Label
+                          content={({ viewBox }) => {
+                            if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                              const cx = viewBox.cx ?? 0;
+                              const cy = viewBox.cy ?? 0;
 
-              <div className="mt-4 flex flex-wrap gap-2 border-t border-border pt-4">
-                {chartData.map((category) => (
-                  <div
-                    key={category.name}
-                    className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs"
-                  >
-                    <span
-                      className="h-2.5 w-2.5 rounded-full"
-                      style={{ backgroundColor: category.fill }}
-                    />
-                    <span className="max-w-[150px] truncate font-medium text-foreground">
-                      {category.label}
-                    </span>
-                    <span className="font-semibold text-muted-foreground">
-                      {category.sharePercentage}%
-                    </span>
+                              return (
+                                <text
+                                  x={cx}
+                                  y={cy}
+                                  textAnchor="middle"
+                                  dominantBaseline="middle"
+                                >
+                                  <tspan
+                                    x={cx}
+                                    y={cy - 4}
+                                    className="fill-foreground text-2xl font-bold"
+                                  >
+                                    {formatCurrency(totalSpent)}
+                                  </tspan>
+                                  <tspan
+                                    x={cx}
+                                    y={cy + 18}
+                                    className="fill-muted-foreground text-xs font-medium"
+                                  >
+                                    Total Spent
+                                  </tspan>
+                                </text>
+                              );
+                            }
+                          }}
+                        />
+                      </Pie>
+                    </PieChart>
+                  </ChartContainer>
+
+                  <div className="mt-4 flex flex-wrap gap-2 border-t border-border pt-4">
+                    {chartData.map((category) => (
+                      <div
+                        key={category.name}
+                        className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs"
+                      >
+                        <span
+                          className="h-2.5 w-2.5 rounded-full"
+                          style={{ backgroundColor: category.fill }}
+                        />
+                        <span className="max-w-[150px] truncate font-medium text-foreground">
+                          {category.label}
+                        </span>
+                        <span className="font-semibold text-muted-foreground">
+                          {category.sharePercentage}%
+                        </span>
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
+                </>
+              )}
             </div>
 
             <div className="max-h-[460px] space-y-3 overflow-y-auto pr-1">
@@ -477,7 +489,7 @@ export default function Budget() {
             value={selectedMonthValue}
             onValueChange={setSelectedMonthValue}
           >
-            <SelectTrigger className="w-full bg-white text-foreground sm:w-64">
+            <SelectTrigger className="w-full bg-background text-foreground sm:w-64">
               <SelectValue placeholder="Select budget month" />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## Summary

This PR addresses two user interface issues on the Budget page:
1. **Month Selector Dropdown Visibility in Dark Mode**: Fixed the `SelectTrigger` styling by replacing the hardcoded `bg-white` with the theme-aware `bg-background`. In dark mode, this prevents white-on-white text rendering, making the month selector text visible.
2. **Category Budgets Visibility**: Corrected the empty state condition for Category Budgets. Instead of checking if there is category spending (`chartData.length === 0`), it now checks if any category limits have been set (`categoryData.length === 0`). If limits are set but no transactions have been recorded yet, the category list displays with 0% usage alongside a dashed chart placeholder, rather than hiding the entire section.

## Related issues

- Related to #201 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open the budget page (`/budget`).
2. Toggle the application to **Dark Mode**.
3. Observe that the budget month selector dropdown text is fully legible and the background matches the theme.
4. Set budget category limits without recording any transactions. Verify that the category limit progress cards are visible on the right, and the left side shows a dashed placeholder stating `"No category spending yet"`.

## Media

## In Light Mode
<img width="794" height="107" alt="image" src="https://github.com/user-attachments/assets/6d7c03bf-da95-4ec8-85c8-74c583fa3bfd" />

## In Dark Mode
<img width="791" height="95" alt="image" src="https://github.com/user-attachments/assets/ccf490d9-503c-49e7-af0a-b16320ad05dd" />

## Validation output

```bash
npm run build

## Output :
vite v6.4.3 building for production...
✓ 3798 modules transformed.
dist/index.html                              1.45 kB │ gzip:   0.62 kB
dist/assets/index-p11Ul8hZ.css             147.92 kB │ gzip:  22.97 kB
dist/assets/purify.es-V6uLfjnH.js           26.92 kB │ gzip:  10.17 kB
dist/assets/index.es-BAAp2350.js           159.60 kB │ gzip:  53.51 kB
dist/assets/html2canvas.esm-QH1iLAAe.js    202.38 kB │ gzip:  48.04 kB
dist/assets/index-B0hC0DSz.js            2,922.73 kB │ gzip: 863.72 kB
```