### PR TITLE
fix(ui): Improve responsive button layout in transactions page header

### DIFF
--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -207,7 +207,7 @@ export default function Transactions() {
       setIsExporting(false);
     }
   };
-  
+
   const safeData = data?.transactions ?? [];
   const safePagination = {
     totalItems: data?.pagination?.totalCount ?? 0,
@@ -216,27 +216,31 @@ export default function Transactions() {
     pageSize: filters.pageSize ?? 20,
   };
 
+  const ActionButtons = () => (
+    <div className="flex flex-col sm:flex-row gap-2">
+      <div className="flex gap-2">
+        <ImportTransactionModal />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setExportModalOpen(true)}
+          disabled={isExporting}
+          className="gap-2 text-black dark:text-white"
+        >
+          <Download className="h-4 w-4" />
+          {isExporting ? "Exporting..." : "Export"}
+        </Button>
+      </div>
+      <AddTransactionDrawer />
+    </div>
+  );
+
   return (
     <PageLayout
       title="All Transactions"
       subtitle="Showing all transactions"
       addMarginTop
-      rightAction={
-        <div className="flex items-center gap-2">
-          <ImportTransactionModal />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setExportModalOpen(true)}
-            disabled={isExporting}
-            className="gap-2 text-black dark:text-white"
-          >
-            <Download className="h-4 w-4" />
-            {isExporting ? "Exporting..." : "Export"}
-          </Button>
-          <AddTransactionDrawer />
-        </div>
-      }
+      rightAction={<ActionButtons />}
     >
       <ExportTransactionModal
         open={exportModalOpen}


### PR DESCRIPTION
## Summary

Improved the responsiveness of the Transactions page header controls to provide a better experience on mobile and tablet devices.

### Changes made:

* Updated the header action button layout to adapt to smaller screen sizes.
* Prevented buttons from overflowing or becoming compressed on mobile devices.
* Improved spacing and alignment between action buttons.
* Ensured buttons wrap or stack appropriately based on available screen width.
* Maintained a consistent and accessible user interface across desktop, tablet, and mobile viewports.

## Related issues

* Closes #199

## Issue template used

* [x] Bug report
* [ ] Feature request
* [ ] Question
* [ ] Other

## Type of change

* [ ] feat
* [x] fix
* [ ] docs
* [ ] refactor
* [ ] test
* [ ] chore

## Scope

* [x] ui (components / pages)
* [ ] design (tokens / styles)
* [ ] state (Redux / API)
* [ ] CI/CD
* [ ] docs

## How to test

1. Start the development server:

   ```bash
   npm run dev
   ```

2. Navigate to the Transactions page.

3. Open browser developer tools and enable responsive/mobile view.

4. Verify that:

   * Header buttons remain visible on small screens.
   * Buttons do not overflow horizontally.
   * Layout remains clean and accessible across mobile, tablet, and desktop breakpoints.
   * Existing button functionality remains unchanged.

## Media

* [x] I attached screenshots or recordings for visual changes.
* [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run lint
✓ Passed

npm run build
✓ Passed

npm test --if-present
✓ Passed
```

## Screenshots or recordings

Before
<img width="482" height="856" alt="image" src="https://github.com/user-attachments/assets/462cd8a3-799d-4541-b588-a61d7f29f3e2" />

After
<img width="483" height="860" alt="image" src="https://github.com/user-attachments/assets/847d3f13-9f60-4077-9439-1c148b53c968" />


## Breaking changes

* [x] No
* [ ] Yes (describe below)

## Checklist

* [x] PR title follows Conventional Commits style.
* [x] I used the PR template fully and did not leave required sections blank.
* [x] I kept this PR focused and reviewable.
* [ ] I added or updated tests where needed.
* [ ] I updated documentation where needed.
* [x] I removed secrets and sensitive information.
