### PR TITLE
fix: Prevent update API call when transaction data is unchanged

### DIFF
--- a/src/components/transaction/transaction-form.tsx
+++ b/src/components/transaction/transaction-form.tsx
@@ -141,6 +141,8 @@ const TransactionForm = (props: {
     },
   });
 
+  const { formState } = form;
+
   useEffect(() => {
     if (isEdit && transactionId && editData) {
       const editAmount =
@@ -292,7 +294,7 @@ const TransactionForm = (props: {
                         shadow-sm border p-2 flex-1 justify-center
                         `,
                         field.value === _TRANSACTION_TYPE.INCOME &&
-                          "!border-primary",
+                        "!border-primary",
                       )}
                     >
                       <RadioGroupItem
@@ -311,7 +313,7 @@ const TransactionForm = (props: {
                         shadow-sm border p-2 flex-1 justify-center
                         `,
                         field.value === _TRANSACTION_TYPE.EXPENSE &&
-                          "!border-primary",
+                        "!border-primary",
                       )}
                     >
                       <RadioGroupItem
@@ -400,7 +402,7 @@ const TransactionForm = (props: {
                                   const flagUrl = getFlagUrl(field.value);
                                   const currency = (
                                     currencyData?.currencies &&
-                                    currencyData.currencies.length > 0
+                                      currencyData.currencies.length > 0
                                       ? currencyData.currencies
                                       : ALL_CURRENCIES
                                   ).find((c) => c.code === field.value);
@@ -428,7 +430,7 @@ const TransactionForm = (props: {
                       </FormControl>
                       <SelectContent>
                         {(currencyData?.currencies &&
-                        currencyData.currencies.length > 0
+                          currencyData.currencies.length > 0
                           ? currencyData.currencies
                           : ALL_CURRENCIES
                         ).map((c) => {
@@ -491,7 +493,7 @@ const TransactionForm = (props: {
                             const name = categoryInputRef.current.trim();
                             if (!name) return;
                             try {
-                              const colors = ["#22C55E","#F97316","#3B82F6","#8B5CF6","#EC4899","#F59E0B","#EF4444","#06B6D4"];
+                              const colors = ["#22C55E", "#F97316", "#3B82F6", "#8B5CF6", "#EC4899", "#F59E0B", "#EF4444", "#06B6D4"];
                               const color = colors[name.length % colors.length];
                               await createCategory({ name, color }).unwrap();
                               field.onChange(name.toLowerCase());
@@ -687,7 +689,9 @@ const TransactionForm = (props: {
             <Button
               type="submit"
               className="w-full"
-              disabled={isScanning || isCreating || isUpdating}
+              disabled={
+                isScanning || isCreating || isUpdating || (isEdit && !formState.isDirty)
+              }
             >
               {isCreating || isUpdating ? (
                 <Loader className="h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Summary

Prevented unnecessary update API calls when editing a transaction without making any changes. The application now verifies whether the transaction data has been modified before sending the update request to the backend.

## Related issues

- Closes #216
- Related to #216

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [ ] ui (components / pages)
- [ ] design (tokens / styles)
- [x] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Open an existing transaction.
2. Click on the **Edit** option.
3. Without modifying any transaction details, click **Update**.
4. Verify through the browser's Network tab that no update API request is sent.
5. Edit one or more transaction fields.
6. Click **Update** again.
7. Verify that the update API request is triggered successfully and the changes are persisted.

## Media

- [x] I attached screenshots or recordings for visual changes.
- [x] I linked the issue or discussion that motivated this change.

## Validation output

```bash
npm run lint
npm run build
npm test --if-present
```

## Screenshots or recordings

Before: 
<img width="1600" height="734" alt="image" src="https://github.com/user-attachments/assets/edaf0917-3458-45d4-b4dd-5935e81cda21" />

After: 
<img width="1600" height="730" alt="image" src="https://github.com/user-attachments/assets/de6f93bc-ea45-44cc-9c6e-972717d65b45" />

## Breaking changes

- [x] No
- [ ] Yes (describe below)

If yes, describe migration steps.

## Checklist

- [x] PR title follows Conventional Commits style.
- [x] I used the PR template fully and did not leave required sections blank.
- [x] I kept this PR focused and reviewable.
- [ ] I added or updated tests where needed.
- [ ] I updated documentation where needed.
- [x] I removed secrets and sensitive information.