### PR TITLE
fix(dashboard): Resolve negative savings rate display issues

### DIFF
--- a/src/lib/format-percentage.ts
+++ b/src/lib/format-percentage.ts
@@ -7,9 +7,9 @@ export const formatPercentage = (
   } = {}
 ): string => {
   const { decimalPlaces = 1, showSign = false, isExpense = false } = options;
-  
+
   if (typeof value !== "number" || isNaN(value)) return "0%";
-    
+
   const absValue = Math.abs(value);
   const formatted = new Intl.NumberFormat("en-US", {
     style: "percent",
@@ -17,10 +17,10 @@ export const formatPercentage = (
     maximumFractionDigits: decimalPlaces,
   }).format(absValue / 100);
 
-  
-  if (!showSign) return formatted;
-   // Special handling for expenses (opposite of normal)
-   if (isExpense) {
+
+  if (!showSign) return value < 0 ? `-${formatted}` : formatted;
+  // Special handling for expenses (opposite of normal)
+  if (isExpense) {
     return value <= 0 ? `+${formatted}` : `-${formatted}`;
   }
 

--- a/src/pages/dashboard/_component/summary-card.tsx
+++ b/src/pages/dashboard/_component/summary-card.tsx
@@ -37,6 +37,7 @@ interface SummaryCardProps {
 const getCardStatus = (value: number, cardType: CardType, expenseRatio?: number): CardStatus => {
   if (cardType === "savings") {
     if (value === 0) return { label: "No Savings Record", colorClass: "text-muted-foreground", Icon: TrendingDownIcon };
+    if (value < 0) return { label: "No Savings", colorClass: "text-rose-500 dark:text-rose-400", Icon: TrendingDownIcon };
     if (value < 10) return { label: "Low Savings", colorClass: "text-rose-500 dark:text-rose-400", Icon: TrendingDownIcon, description: `${value.toFixed(1)}% saved` };
     if (value < 20) return { label: "Moderate", colorClass: "text-amber-500 dark:text-amber-400", Icon: TrendingDownIcon, description: `${expenseRatio?.toFixed(0)}% spent` };
     if (expenseRatio && expenseRatio > 75) return { label: "High Spend", colorClass: "text-rose-500 dark:text-rose-400", Icon: TrendingDownIcon, description: `${expenseRatio.toFixed(0)}% spent` };


### PR DESCRIPTION
## Summary

This PR resolves the negative savings rate display issues on the Dashboard overview page:
1. Fixed `formatPercentage` in `src/lib/format-percentage.ts` to preserve the negative (`-`) sign for values below 0 when `showSign` is set to `false` (which caused negative savings rates to display as positive in the main card metric).
2. Updated `getCardStatus` in `src/pages/dashboard/_component/summary-card.tsx` to handle negative savings rate values, returning a clean status of `No Savings` in red without displaying the contradictory and redundant `· -X% saved` description suffix.

## Related issues

- Closes #210 
## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [ ] state (Redux / API)
- [ ] CI/CD
- [ ] docs

## How to test

1. Log in to an account where total expenses exceed total income for the past 30 days.
2. View the dashboard overview page cards.
3. Validate that the **Savings Rate** main card metric shows the negative sign (e.g. `-1,753.0%`).
4. Validate that the status subtext underneath says **`No Savings`** in red and has no extra description suffix.

## Media
<img width="749" height="235" alt="Screenshot 2026-06-15 230553" src="https://github.com/user-attachments/assets/8c598e27-490b-4c65-8ea8-7650ba5be05f" />

## Validation output

```bash
npm run build

## Output :
vite v6.4.3 building for production...
✓ 3801 modules transformed.
dist/index.html                              1.45 kB │ gzip:   0.62 kB
dist/assets/index-BkKg65i8.css             148.36 kB │ gzip:  23.06 kB
dist/assets/purify.es-V6uLfjnH.js           26.92 kB │ gzip:  10.17 kB
dist/assets/index.es-DqkpntiC.js           159.60 kB │ gzip:  53.52 kB
dist/assets/html2canvas.esm-QH1iLAAe.js    202.38 kB │ gzip:  48.04 kB
dist/assets/index-D0Q2fUMn.js            2,929.06 kB │ gzip: 865.21 kB
```