### PR TITLE
fix(dashboard): Enhance pie chart percentage decimals and tooltip spacing

### DIFF
--- a/src/pages/dashboard/expense-pie-chart.tsx
+++ b/src/pages/dashboard/expense-pie-chart.tsx
@@ -68,7 +68,28 @@ const ExpensePieChart = ({ dateRange }: { dateRange?: DateRangeType }) => {
               <PieChart>
                 <ChartTooltip
                   cursor={false}
-                  content={<ChartTooltipContent className="bg-card border border-border shadow-lg rounded-xl p-2.5" />}
+                  content={
+                    <ChartTooltipContent
+                      className="bg-card border border-border shadow-lg rounded-xl p-2.5"
+                      formatter={(value, name, item) => {
+                        const pct = item?.payload?.percentage ?? 0;
+                        const formattedPct = pct > 0 && pct < 0.01 ? "<0.01%" : formatPercentage(pct, { decimalPlaces: 2 });
+                        return (
+                          <div className="flex items-center justify-between gap-6 w-full min-w-[200px]">
+                            <span className="text-muted-foreground capitalize">{name}</span>
+                            <div className="flex items-center gap-2 shrink-0">
+                              <span className="font-semibold text-foreground metric-numeric">
+                                {formatCurrency(Number(value))}
+                              </span>
+                              <span className="text-[11px] text-muted-foreground">
+                                ({formattedPct})
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      }}
+                    />
+                  }
                 />
                 <Pie
                   data={categories}
@@ -126,7 +147,7 @@ const ExpensePieChart = ({ dateRange }: { dateRange?: DateRangeType }) => {
                         {formatCurrency(entry.value, {})}
                       </span>
                       <span className="text-[11px] text-muted-foreground">
-                        ({formatPercentage(entry.percentage, { decimalPlaces: 0 })})
+                        ({entry.percentage > 0 && entry.percentage < 0.01 ? "<0.01%" : formatPercentage(entry.percentage, { decimalPlaces: 2 })})
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

This PR improves the accuracy and formatting of the Expense Breakdown donut chart on the Dashboard Overview screen:
1. Category percentages are now calculated and formatted to one decimal place (e.g. `91.60%` instead of `92%`).
2. The donut chart's hover tooltip has been enhanced to display fully formatted currency values (including the `$` symbol) with clear, responsive spacing between the category label and the amount.

## Related issues

- Closes #212 

## Issue template used

- [x] Bug report
- [ ] Feature request
- [ ] Question
- [ ] Other

## Type of change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Scope

- [x] ui (components / pages)
- [ ] design (tokens / styles)
- [x] server (endpoints / services / DB)
- [ ] CI/CD
- [ ] docs

## How to test

1. Hover over any sector of the Expense Breakdown chart. Verify that the tooltip displays formatted currency (e.g., `$10,048,691.43`) with clean spacing.
2. Review the legend items and verify that they render with one decimal place of precision (e.g. `91.60%` and `0.40%`).

## Screenshot
<img width="218" height="341" alt="image" src="https://github.com/user-attachments/assets/9cce2e69-809b-4097-bcb7-2a895a48cc28" />

## Validation output

```bash
npm run build

Output :
vite v6.4.3 building for production...
✓ 3801 modules transformed.
dist/index.html                              1.45 kB │ gzip:   0.63 kB
dist/assets/index-DgiTbCy-.css             148.40 kB │ gzip:  23.07 kB
dist/assets/purify.es-V6uLfjnH.js           26.92 kB │ gzip:  10.17 kB
dist/assets/index.es-CBJLNOPE.js           159.60 kB │ gzip:  53.52 kB
dist/assets/html2canvas.esm-QH1iLAAe.js    202.38 kB │ gzip:  48.04 kB
dist/assets/index-Bj_HWYWV.js            2,929.79 kB │ gzip: 865.36 kB
```