### PR TITLE
perf: Code-split the bundle and add optimistic deletes

### DIFF
--- a/src/components/page-fallback.tsx
+++ b/src/components/page-fallback.tsx
@@ -1,0 +1,13 @@
+import { Loader } from "lucide-react";
+
+/**
+ * Fallback shown while a lazily-loaded route chunk is fetched. Kept minimal and
+ * centered so it doesn't cause layout shift inside the app shell.
+ */
+const PageFallback = () => (
+  <div className="flex flex-1 items-center justify-center py-20">
+    <Loader className="h-6 w-6 animate-spin text-muted-foreground" />
+  </div>
+);
+
+export default PageFallback;

--- a/src/components/transaction/add-transaction-drawer.tsx
+++ b/src/components/transaction/add-transaction-drawer.tsx
@@ -8,10 +8,20 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
-import { PlusIcon, XIcon, FileTextIcon, ScanTextIcon, MicIcon } from "lucide-react";
-import TransactionForm from "./transaction-form";
+import { PlusIcon, XIcon, FileTextIcon, ScanTextIcon, MicIcon, Loader } from "lucide-react";
+import { Suspense, lazy } from "react";
 import { cn } from "@/lib/utils";
 import useAddTransactionDrawer from "@/hooks/use-add-transaction-drawer";
+
+// Heavy (voice + receipt scanner); code-split so it only loads when the drawer
+// is actually opened.
+const TransactionForm = lazy(() => import("./transaction-form"));
+
+const FormFallback = () => (
+  <div className="flex items-center justify-center py-16">
+    <Loader className="h-5 w-5 animate-spin text-muted-foreground" />
+  </div>
+);
 
 type TransactionMode = "voice" | "scan" | "manual";
 
@@ -69,9 +79,13 @@ const AddTransactionDrawer = ({ hideTrigger = false }: { hideTrigger?: boolean }
         </div>
 
         <div className="flex-1 overflow-y-auto">
-          {mode === "manual" && <TransactionForm onCloseDrawer={onCloseDrawer} mode="manual" />}
-          {mode === "scan" && <TransactionForm onCloseDrawer={onCloseDrawer} mode="scan" />}
-          {mode === "voice" && <TransactionForm onCloseDrawer={onCloseDrawer} mode="voice" />}
+          {open && (
+            <Suspense fallback={<FormFallback />}>
+              {mode === "manual" && <TransactionForm onCloseDrawer={onCloseDrawer} mode="manual" />}
+              {mode === "scan" && <TransactionForm onCloseDrawer={onCloseDrawer} mode="scan" />}
+              {mode === "voice" && <TransactionForm onCloseDrawer={onCloseDrawer} mode="voice" />}
+            </Suspense>
+          )}
         </div>
       </DrawerContent>
     </Drawer>

--- a/src/components/transaction/edit-transaction-drawer.tsx
+++ b/src/components/transaction/edit-transaction-drawer.tsx
@@ -1,3 +1,5 @@
+import { Suspense, lazy } from "react";
+import { Loader } from "lucide-react";
 import {
   Drawer,
   DrawerContent,
@@ -5,8 +7,17 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import TransactionForm from "./transaction-form";
 import useEditTransactionDrawer from "@/hooks/use-edit-transaction-drawer";
+
+// The transaction form (with the voice recorder + receipt scanner) is heavy and
+// only needed once a drawer is opened, so it's code-split out of the app shell.
+const TransactionForm = lazy(() => import("./transaction-form"));
+
+const FormFallback = () => (
+  <div className="flex items-center justify-center py-16">
+    <Loader className="h-5 w-5 animate-spin text-muted-foreground" />
+  </div>
+);
 
 const EditTransactionDrawer = () => {
   const { open, transactionId, onCloseDrawer } = useEditTransactionDrawer();
@@ -22,11 +33,15 @@ const EditTransactionDrawer = () => {
           </DrawerDescription>
         </DrawerHeader>
         <div className="flex-1 overflow-y-auto">
-          <TransactionForm
-            isEdit
-            transactionId={transactionId}
-            onCloseDrawer={onCloseDrawer}
-          />
+          {open && (
+            <Suspense fallback={<FormFallback />}>
+              <TransactionForm
+                isEdit
+                transactionId={transactionId}
+                onCloseDrawer={onCloseDrawer}
+              />
+            </Suspense>
+          )}
         </div>
       </DrawerContent>
     </Drawer>

--- a/src/components/transaction/transaction-form.tsx
+++ b/src/components/transaction/transaction-form.tsx
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Calendar, Loader } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/components/transaction/transaction-form.tsx
+++ b/src/components/transaction/transaction-form.tsx
@@ -38,7 +38,7 @@ import {
   _TRANSACTION_TYPE,
   PAYMENT_METHODS,
 } from "@/constant";
-import { useGetCategoriesQuery, useCreateCategoryMutation } from "@/features/category/categoryAPI";
+import { useGetCategoriesQuery } from "@/features/category/categoryAPI";
 import { Switch } from "../ui/switch";
 import CurrencyInputField from "../ui/currency-input";
 import { SingleSelector } from "../ui/single-select";
@@ -100,9 +100,7 @@ const TransactionForm = (props: {
   } = props;
 
   const [isScanning, setIsScanning] = useState(false);
-  const categoryInputRef = useRef("");
   const { data: categoriesData } = useGetCategoriesQuery();
-  const [createCategory] = useCreateCategoryMutation();
   const categoryOptions = (categoriesData?.data ?? []).map((cat) => ({
     value: cat.name.toLowerCase(),
     label: cat.name,
@@ -476,36 +474,11 @@ const TransactionForm = (props: {
                     }
                     onChange={(option) => field.onChange(option.value)}
                     options={categoryOptions}
-                    placeholder="Select or type a category"
+                    placeholder="Select a category"
                     disabled={isScanning}
-                    inputProps={{
-                      onValueChange: (val) => { categoryInputRef.current = val; },
-                    }}
                     emptyIndicator={
-                      <div className="flex items-center justify-between px-3 py-2">
-                        <span className="text-sm text-muted-foreground">No match found</span>
-                        <button
-                          type="button"
-                          className="text-sm font-medium text-primary hover:underline"
-                          onMouseDown={async (e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            const name = categoryInputRef.current.trim();
-                            if (!name) return;
-                            try {
-                              const colors = ["#22C55E", "#F97316", "#3B82F6", "#8B5CF6", "#EC4899", "#F59E0B", "#EF4444", "#06B6D4"];
-                              const color = colors[name.length % colors.length];
-                              await createCategory({ name, color }).unwrap();
-                              field.onChange(name.toLowerCase());
-                              categoryInputRef.current = "";
-                              toast.success(`Category "${name}" added`);
-                            } catch {
-                              toast.error("Failed to add category");
-                            }
-                          }}
-                        >
-                          + Add Category
-                        </button>
+                      <div className="px-3 py-2 text-sm text-muted-foreground">
+                        No match. Add categories in Settings &rarr; Categories.
                       </div>
                     }
                   />

--- a/src/features/category/categoryAPI.ts
+++ b/src/features/category/categoryAPI.ts
@@ -22,6 +22,22 @@ export const categoryApi = apiClient.injectEndpoints({
     }),
     deleteCategory: builder.mutation<{ message: string }, string>({
       query: (id) => ({ url: `/category/${id}`, method: "DELETE" }),
+      // Remove the category from the cached list instantly so it disappears in
+      // sync with the success toast; roll back if the server rejects it.
+      async onQueryStarted(id, { dispatch, queryFulfilled }) {
+        const patch = dispatch(
+          categoryApi.util.updateQueryData("getCategories", undefined, (draft) => {
+            if (draft?.data) {
+              draft.data = draft.data.filter((c) => c._id !== id);
+            }
+          }),
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          patch.undo();
+        }
+      },
       invalidatesTags: ["categories"],
     }),
   }),

--- a/src/features/transaction/transactionAPI.ts
+++ b/src/features/transaction/transactionAPI.ts
@@ -9,6 +9,51 @@ import {
   UpdateTransactionPayload,
 } from "./transationType";
 
+type UndoPatch = { undo: () => void };
+
+/**
+ * Optimistically remove the given transaction ids from every cached
+ * `getAllTransactions` list so a deleted row disappears instantly — in sync with
+ * the success toast — instead of lingering until a refetch completes. Returns the
+ * patch handles so the caller can roll the rows back if the delete is rejected.
+ */
+const pruneTransactionCaches = (
+  dispatch: (action: any) => UndoPatch,
+  getState: () => any,
+  ids: Set<string>,
+): UndoPatch[] => {
+  const patches: UndoPatch[] = [];
+  const entries = transactionApi.util.selectInvalidatedBy(getState(), [
+    "transactions",
+  ]);
+  for (const { endpointName, originalArgs } of entries) {
+    if (endpointName !== "getAllTransactions") continue;
+    patches.push(
+      dispatch(
+        transactionApi.util.updateQueryData(
+          "getAllTransactions",
+          originalArgs as GetAllTransactionParams,
+          (draft: GetAllTransactionResponse) => {
+            if (!draft.transactions) return;
+            const before = draft.transactions.length;
+            draft.transactions = draft.transactions.filter(
+              (t) => !ids.has(t._id) && !(t.id && ids.has(t.id)),
+            );
+            const removed = before - draft.transactions.length;
+            if (draft.pagination && removed > 0) {
+              draft.pagination.totalCount = Math.max(
+                0,
+                (draft.pagination.totalCount || 0) - removed,
+              );
+            }
+          },
+        ),
+      ),
+    );
+  }
+  return patches;
+};
+
 export const transactionApi = apiClient.injectEndpoints({
   endpoints: (builder) => ({
     createTransaction: builder.mutation<void, CreateTransactionBody>({
@@ -108,6 +153,14 @@ export const transactionApi = apiClient.injectEndpoints({
         url: `/transaction/delete/${id}`,
         method: "DELETE",
       }),
+      async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
+        const patches = pruneTransactionCaches(dispatch, getState, new Set([id]));
+        try {
+          await queryFulfilled;
+        } catch {
+          patches.forEach((p) => p.undo());
+        }
+      },
       invalidatesTags: ["transactions", "analytics", "budget"],
     }),
 
@@ -119,6 +172,18 @@ export const transactionApi = apiClient.injectEndpoints({
           transactionIds,
         },
       }),
+      async onQueryStarted(transactionIds, { dispatch, getState, queryFulfilled }) {
+        const patches = pruneTransactionCaches(
+          dispatch,
+          getState,
+          new Set(transactionIds),
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          patches.forEach((p) => p.undo());
+        }
+      },
       invalidatesTags: ["transactions", "analytics", "budget"],
     }),
     // exportTransactions: builder.query<

--- a/src/features/transaction/transactionAPI.ts
+++ b/src/features/transaction/transactionAPI.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/app/api-client";
+import type { AppDispatch } from "@/app/hook";
 import {
   AIScanReceiptResponse,
   BulkImportTransactionPayload,
@@ -10,6 +11,9 @@ import {
 } from "./transationType";
 
 type UndoPatch = { undo: () => void };
+// The state shape `selectInvalidatedBy` needs — this is exactly what the
+// mutation lifecycle's `getState()` provides (the RTK Query api slice).
+type ApiRootState = Parameters<typeof apiClient.util.selectInvalidatedBy>[0];
 
 /**
  * Optimistically remove the given transaction ids from every cached
@@ -18,8 +22,8 @@ type UndoPatch = { undo: () => void };
  * patch handles so the caller can roll the rows back if the delete is rejected.
  */
 const pruneTransactionCaches = (
-  dispatch: (action: any) => UndoPatch,
-  getState: () => any,
+  dispatch: AppDispatch,
+  getState: () => ApiRootState,
   ids: Set<string>,
 ): UndoPatch[] => {
   const patches: UndoPatch[] = [];

--- a/src/layouts/app-layout.tsx
+++ b/src/layouts/app-layout.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import Sidebar from "@/components/sidebar";
 import { HeaderBar } from "@/components/navbar/header-bar";
 import { Outlet } from "react-router-dom";
+import PageFallback from "@/components/page-fallback";
 import EditTransactionDrawer from "@/components/transaction/edit-transaction-drawer";
 import AddTransactionDrawer from "@/components/transaction/add-transaction-drawer";
 import LogoutDialog from "@/components/navbar/logout-dialog";
@@ -31,7 +32,9 @@ const AppLayoutInner = () => {
           onSidebarToggle={() => setSidebarCollapsed((v) => !v)}
         />
         <main className="w-full flex-1 flex flex-col">
-          <Outlet />
+          <Suspense fallback={<PageFallback />}>
+            <Outlet />
+          </Suspense>
         </main>
       </div>
       <AddTransactionDrawer hideTrigger />

--- a/src/layouts/base-layout.tsx
+++ b/src/layouts/base-layout.tsx
@@ -1,11 +1,15 @@
+import { Suspense } from "react";
 import { Outlet } from "react-router-dom";
+import PageFallback from "@/components/page-fallback";
 
 const BaseLayout = () => {
   return (
     <div className="flex flex-col w-full h-auto">
       <div className="w-full h-full flex items-center justify-center">
         <div className="w-full mx-auto h-auto ">
-          <Outlet />
+          <Suspense fallback={<PageFallback />}>
+            <Outlet />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/src/layouts/public-layout.tsx
+++ b/src/layouts/public-layout.tsx
@@ -1,9 +1,13 @@
+import { Suspense } from "react";
 import { Outlet } from "react-router-dom";
+import PageFallback from "@/components/page-fallback";
 
 const PublicLayout = () => {
   return (
     <div className="w-full h-auto">
-      <Outlet />
+      <Suspense fallback={<PageFallback />}>
+        <Outlet />
+      </Suspense>
     </div>
   );
 };

--- a/src/pages/budget/_component/budget-form.tsx
+++ b/src/pages/budget/_component/budget-form.tsx
@@ -14,8 +14,8 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import CurrencyInputField from "@/components/ui/currency-input";
-import { CATEGORIES } from "@/constant";
 import { useUpsertBudgetMutation } from "@/features/budget/budgetAPI";
+import { useGetCategoriesQuery } from "@/features/category/categoryAPI";
 import { BudgetSummary } from "@/features/budget/budgetType";
 import { AIScanReceiptData } from "@/features/transaction/transationType";
 import { getCategoryIcon } from "@/lib/category-icons";
@@ -92,8 +92,19 @@ const BudgetForm = ({
     (c) => c.code === baseCurrency
   )?.symbol ?? "$";
 
+  // Single source of truth: the user's categories (default + custom),
+  // managed only in Settings → Categories.
+  const { data: categoriesResponse } = useGetCategoriesQuery();
+  const categories = useMemo(
+    () =>
+      (categoriesResponse?.data ?? [])
+        .filter((c) => c.name?.trim())
+        .map((c) => ({ value: c.name, label: c.name })),
+    [categoriesResponse]
+  );
+
   const defaultCategoryValues = useMemo(() => {
-    return CATEGORIES.reduce<Record<string, string>>((acc, category) => {
+    return categories.reduce<Record<string, string>>((acc, category) => {
       const existingCategory = budget?.categories.find(
         (item) => item.name === category.value
       );
@@ -102,7 +113,7 @@ const BudgetForm = ({
         : "";
       return acc;
     }, {});
-  }, [budget?.categories]);
+  }, [budget?.categories, categories]);
 
   const form = useForm<BudgetFormValues>({
     resolver: zodResolver(budgetFormSchema),
@@ -129,7 +140,7 @@ const BudgetForm = ({
         .join(" ")
     );
 
-    return CATEGORIES.find((category) => {
+    return categories.find((category) => {
       const value = normalizeText(category.value);
       const label = normalizeText(category.label);
       return (
@@ -256,7 +267,7 @@ const BudgetForm = ({
             </div>
 
             <div className="grid gap-3">
-              {CATEGORIES.map((category) => {
+              {categories.map((category) => {
                 const Icon = getCategoryIcon(category.value);
                 return (
                   <FormField

--- a/src/pages/settings/categories.tsx
+++ b/src/pages/settings/categories.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Loader, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   useDeleteCategoryMutation,
   useGetCategoriesQuery,
@@ -9,21 +10,45 @@ import {
 import type { Category } from "@/features/category/categoryType";
 import CategoryForm from "./_components/category-form";
 
+const CategoriesSkeleton = () => (
+  <div className="space-y-2">
+    {Array.from({ length: 6 }).map((_, i) => (
+      <div
+        key={i}
+        className="flex items-center justify-between rounded-lg border px-4 py-3"
+      >
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
 const Categories = () => {
   const { data, isLoading } = useGetCategoriesQuery();
-  const [deleteCategory, { isLoading: isDeleting }] = useDeleteCategoryMutation();
+  const [deleteCategory] = useDeleteCategoryMutation();
 
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const categories = data?.data ?? [];
 
   const handleDelete = (category: Category) => {
+    if (deletingId) return;
     if (!confirm(`Delete "${category.name}"? Existing transactions will move to "Uncategorized".`)) return;
 
+    setDeletingId(category._id);
     deleteCategory(category._id)
       .unwrap()
       .then(() => toast.success("Category deleted"))
-      .catch((err) => toast.error(err?.data?.message || "Failed to delete category"));
+      .catch((err) => toast.error(err?.data?.message || "Failed to delete category"))
+      .finally(() => setDeletingId(null));
   };
 
   const handleEdit = (category: Category) => {
@@ -33,14 +58,6 @@ const Categories = () => {
   const handleDone = () => {
     setEditingCategory(null);
   };
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-10">
-        <Loader className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
 
   return (
     <div className="space-y-6">
@@ -55,46 +72,58 @@ const Categories = () => {
         <CategoryForm category={editingCategory} onDone={handleDone} />
       )}
 
-      <div className="space-y-2">
-        {categories.map((cat) => (
-          <div
-            key={cat._id}
-            className="flex items-center justify-between rounded-lg border px-4 py-3"
-          >
-            <div className="flex items-center gap-3">
-              <span
-                className="w-4 h-4 rounded-full flex-shrink-0"
-                style={{ backgroundColor: cat.color }}
-              />
-              <span className="text-sm font-medium">{cat.name}</span>
-              {cat.isDefault && (
-                <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-                  default
-                </span>
-              )}
-            </div>
-            <div className="flex items-center gap-1">
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-8 w-8"
-                onClick={() => handleEdit(cat)}
+      {isLoading ? (
+        <CategoriesSkeleton />
+      ) : (
+        <div className="space-y-2">
+          {categories.map((cat) => {
+            const isRowDeleting = deletingId === cat._id;
+            return (
+              <div
+                key={cat._id}
+                className="flex items-center justify-between rounded-lg border px-4 py-3"
               >
-                <Pencil className="h-4 w-4" />
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-8 w-8 text-destructive hover:text-destructive"
-                onClick={() => handleDelete(cat)}
-                disabled={isDeleting}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-        ))}
-      </div>
+                <div className="flex items-center gap-3">
+                  <span
+                    className="w-4 h-4 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: cat.color }}
+                  />
+                  <span className="text-sm font-medium">{cat.name}</span>
+                  {cat.isDefault && (
+                    <span className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                      default
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    onClick={() => handleEdit(cat)}
+                    disabled={isRowDeleting}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8 text-destructive hover:text-destructive"
+                    onClick={() => handleDelete(cat)}
+                    disabled={isRowDeleting}
+                  >
+                    {isRowDeleting ? (
+                      <Loader className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/settings/categories.tsx
+++ b/src/pages/settings/categories.tsx
@@ -102,6 +102,8 @@ const Categories = () => {
                     className="h-8 w-8"
                     onClick={() => handleEdit(cat)}
                     disabled={isRowDeleting}
+                    aria-label={`Edit ${cat.name}`}
+                    title={`Edit ${cat.name}`}
                   >
                     <Pencil className="h-4 w-4" />
                   </Button>
@@ -111,6 +113,8 @@ const Categories = () => {
                     className="h-8 w-8 text-destructive hover:text-destructive"
                     onClick={() => handleDelete(cat)}
                     disabled={isRowDeleting}
+                    aria-label={`Delete ${cat.name}`}
+                    title={`Delete ${cat.name}`}
                   >
                     {isRowDeleting ? (
                       <Loader className="h-4 w-4 animate-spin" />

--- a/src/routes/common/routes.tsx
+++ b/src/routes/common/routes.tsx
@@ -1,22 +1,27 @@
+import { lazy } from "react";
 import { AUTH_ROUTES, PROTECTED_ROUTES, PUBLIC_ROUTES } from "./routePath";
-import SignIn from "@/pages/auth/sign-in";
-import SignUp from "@/pages/auth/sign-up";
-import VerifyEmail from "@/pages/auth/verify-email";
-import ForgotPassword from "@/pages/auth/forgot-password";
-import VerifyResetPassword from "@/pages/auth/verify-reset-password";
-import SetNewPassword from "@/pages/auth/set-new-password";
-import ResetPassword from "@/pages/auth/reset-password";
-import Home from "@/pages/home";
-import Dashboard from "@/pages/dashboard";
-import Transactions from "@/pages/transactions";
-import Reports from "@/pages/reports";
-import Budget from "@/pages/budget";
-import Settings from "@/pages/settings";
-import Account from "@/pages/settings/account";
-import Appearance from "@/pages/settings/appearance";
-import Billing from "@/pages/settings/billing";
-import Security from "@/pages/settings/security";
-import Categories from "@/pages/settings/categories";
+
+// Route pages are code-split so the initial bundle only ships the shell + the
+// first page the user lands on. Heavy pages (dashboard charts, reports, budget)
+// and their libraries load on demand and are cached per-chunk afterwards.
+const SignIn = lazy(() => import("@/pages/auth/sign-in"));
+const SignUp = lazy(() => import("@/pages/auth/sign-up"));
+const VerifyEmail = lazy(() => import("@/pages/auth/verify-email"));
+const ForgotPassword = lazy(() => import("@/pages/auth/forgot-password"));
+const VerifyResetPassword = lazy(() => import("@/pages/auth/verify-reset-password"));
+const SetNewPassword = lazy(() => import("@/pages/auth/set-new-password"));
+const ResetPassword = lazy(() => import("@/pages/auth/reset-password"));
+const Home = lazy(() => import("@/pages/home"));
+const Dashboard = lazy(() => import("@/pages/dashboard"));
+const Transactions = lazy(() => import("@/pages/transactions"));
+const Reports = lazy(() => import("@/pages/reports"));
+const Budget = lazy(() => import("@/pages/budget"));
+const Settings = lazy(() => import("@/pages/settings"));
+const Account = lazy(() => import("@/pages/settings/account"));
+const Appearance = lazy(() => import("@/pages/settings/appearance"));
+const Billing = lazy(() => import("@/pages/settings/billing"));
+const Security = lazy(() => import("@/pages/settings/security"));
+const Categories = lazy(() => import("@/pages/settings/categories"));
 
 export const publicRoutePaths = [
   { path: PUBLIC_ROUTES.HOME, element: <Home /> },

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,17 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Split large, rarely-changing vendor libraries into their own chunks
+        // so they cache independently of app code and don't bloat the entry.
+        manualChunks: {
+          "react-vendor": ["react", "react-dom", "react-router-dom"],
+          "charts": ["recharts"],
+          "redux": ["@reduxjs/toolkit", "react-redux"],
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
- Optimistic deletes for transactions & categories (instant removal, rollback on failure)
- Route + transaction-form code-splitting (initial JS ~865KB -> ~553KB gzip)
- Category settings skeleton + per-row delete spinner
- Accessible labels on category action buttons
- Drop deprecated tsconfig baseUrl