### PR TITLE
feat: Improve AI agent readiness (OAuth discovery, WebMCP, auth.md, markdown)

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/webmcp.js" defer></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,98 @@
+import { next } from "@vercel/edge";
+
+/**
+ * Markdown for Agents.
+ *
+ * When an agent requests a page with `Accept: text/markdown`, serve a markdown
+ * representation of the page instead of the SPA HTML shell. Browsers (which do
+ * not send that Accept value) keep getting the normal HTML app.
+ *
+ * See https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/
+ */
+export const config = {
+  // Only intercept public, content routes. The SPA and assets are untouched.
+  matcher: ["/", "/sign-in", "/sign-up"],
+};
+
+const HOME_MARKDOWN = `# VoiceyBill
+
+Personal financial platform — track income and expenses with voice input, AI
+receipt scanning, analytics charts, and scheduled email reports.
+
+## What you can do
+
+- **Voice input** — add transactions by speaking naturally.
+- **AI receipt scanning** — snap a receipt and let VoiceyBill categorize it.
+- **Transactions** — record, edit, and delete income and expenses.
+- **Budgets** — set budgets and track spending against them.
+- **Analytics** — spending insights and charts over any period.
+- **Reports** — generate and schedule financial reports by email.
+
+## For agents
+
+- API base: \`https://voiceybill-server.vercel.app/api\`
+- Authentication: [/auth.md](https://voiceybill.com/auth.md)
+- MCP server card: [/.well-known/mcp/server-card.json](https://voiceybill.com/.well-known/mcp/server-card.json)
+- API catalog: [/.well-known/api-catalog](https://voiceybill.com/.well-known/api-catalog)
+- Agent skills: [/.well-known/agent-skills/index.json](https://voiceybill.com/.well-known/agent-skills/index.json)
+
+## Get started
+
+Create an account at [/sign-up](https://voiceybill.com/sign-up) or sign in at
+[/sign-in](https://voiceybill.com/sign-in).
+`;
+
+const SIGN_IN_MARKDOWN = `# Sign in to VoiceyBill
+
+Authenticate with your verified email and password to access your VoiceyBill
+account.
+
+Agents: authenticate programmatically via \`POST https://voiceybill-server.vercel.app/api/auth/login\`.
+See [/auth.md](https://voiceybill.com/auth.md) for the full flow.
+`;
+
+const SIGN_UP_MARKDOWN = `# Create a VoiceyBill account
+
+Sign up with your email and a password, then verify the one-time code sent to
+your inbox.
+
+Agents: register via \`POST https://voiceybill-server.vercel.app/api/auth/register\`
+then verify with \`POST /api/auth/verify-otp\`. See [/auth.md](https://voiceybill.com/auth.md).
+`;
+
+const MARKDOWN_BY_PATH: Record<string, string> = {
+  "/": HOME_MARKDOWN,
+  "/sign-in": SIGN_IN_MARKDOWN,
+  "/sign-up": SIGN_UP_MARKDOWN,
+};
+
+function wantsMarkdown(accept: string | null): boolean {
+  if (!accept) return false;
+  // Only when markdown is explicitly requested — never for browsers that send
+  // "text/html,...;q=0.9,text/markdown" as a low-priority afterthought.
+  return /(^|,)\s*text\/markdown\b/i.test(accept);
+}
+
+export default function middleware(request: Request) {
+  const url = new URL(request.url);
+  const markdown = MARKDOWN_BY_PATH[url.pathname];
+
+  if (
+    request.method === "GET" &&
+    markdown &&
+    wantsMarkdown(request.headers.get("accept"))
+  ) {
+    return new Response(markdown, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "x-markdown-tokens": String(Math.ceil(markdown.length / 4)),
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "public, max-age=300",
+        Vary: "Accept",
+      },
+    });
+  }
+
+  return next();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@reduxjs/toolkit": "^2.12.0",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-table": "^8.21.3",
+        "@vercel/edge": "^1.2.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3328,6 +3329,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@vercel/edge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.3.1.tgz",
+      "integrity": "sha512-k0tKWeYEWOv6qU6+Z8+hv2Nt/u3vFHRZdB0uvwE0DxoddU/5kWX/Chu8F6ojvqmRlnZwuX/7kyZFVeCP6DxqBg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@reduxjs/toolkit": "^2.12.0",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-table": "^8.21.3",
+    "@vercel/edge": "^1.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -1,0 +1,28 @@
+{
+  "issuer": "https://voiceybill.com",
+  "authorization_endpoint": "https://voiceybill.com/sign-in",
+  "token_endpoint": "https://voiceybill-server.vercel.app/api/auth/login",
+  "registration_endpoint": "https://voiceybill-server.vercel.app/api/auth/register",
+  "jwks_uri": "https://voiceybill-server.vercel.app/.well-known/jwks.json",
+  "grant_types_supported": ["password"],
+  "response_types_supported": ["token"],
+  "token_endpoint_auth_methods_supported": ["client_secret_post"],
+  "scopes_supported": [
+    "transactions:read",
+    "transactions:write",
+    "analytics:read",
+    "reports:read",
+    "reports:write",
+    "budgets:read",
+    "budgets:write"
+  ],
+  "service_documentation": "https://voiceybill.com/auth.md",
+  "ui_locales_supported": ["en"],
+  "agent_auth": {
+    "skill": "https://isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md",
+    "register_uri": "https://voiceybill-server.vercel.app/api/auth/register",
+    "supported_identity_types": ["verified_email"],
+    "supported_credential_types": ["jwt_bearer"],
+    "documentation": "https://voiceybill.com/auth.md"
+  }
+}

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,0 +1,15 @@
+{
+  "resource": "https://voiceybill-server.vercel.app/api",
+  "authorization_servers": ["https://voiceybill.com"],
+  "bearer_methods_supported": ["header"],
+  "scopes_supported": [
+    "transactions:read",
+    "transactions:write",
+    "analytics:read",
+    "reports:read",
+    "reports:write",
+    "budgets:read",
+    "budgets:write"
+  ],
+  "resource_documentation": "https://voiceybill.com/auth.md"
+}

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,18 +1,57 @@
-# VoiceyBill Authentication
+# auth.md
+
+VoiceyBill authentication and agent-registration guide.
+
+## Agent Audience
+
+This document is for AI agents that need to authenticate on behalf of a
+VoiceyBill user in order to call the VoiceyBill API
+(`https://voiceybill-server.vercel.app/api`). Agents act with the full
+permissions of the authenticated user.
 
 ## Overview
 
-VoiceyBill uses JWT-based authentication for API access.
+VoiceyBill uses JWT (bearer token) authentication. A user account is required;
+agents obtain a token by authenticating with the user's verified email and
+password.
 
-## Registration
+## Discovery Metadata
 
-Agents can register users via the signup endpoint or authenticate via Google OAuth.
+- Authorization server metadata: [`/.well-known/oauth-authorization-server`](/.well-known/oauth-authorization-server)
+- Protected resource metadata: [`/.well-known/oauth-protected-resource`](/.well-known/oauth-protected-resource)
 
-### Endpoints
+## agent_auth
 
-- **POST** `https://voiceybill-server.vercel.app/api/auth/signup` — Create a new account
-- **POST** `https://voiceybill-server.vercel.app/api/auth/login` — Authenticate and receive JWT
-- **POST** `https://voiceybill-server.vercel.app/api/auth/google` — Authenticate via Google OAuth
+```json
+{
+  "skill": "https://isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md",
+  "register_uri": "https://voiceybill-server.vercel.app/api/auth/register",
+  "supported_identity_types": ["verified_email"],
+  "supported_credential_types": ["jwt_bearer"],
+  "authorization_server": "https://voiceybill.com/.well-known/oauth-authorization-server",
+  "protected_resource": "https://voiceybill.com/.well-known/oauth-protected-resource"
+}
+```
+
+## Registration / Provisioning
+
+Create an account, then verify the email with the one-time code that is emailed.
+
+- **POST** `https://voiceybill-server.vercel.app/api/auth/register` — Create a new account
+- **POST** `https://voiceybill-server.vercel.app/api/auth/verify-otp` — Verify the email with the OTP
+- **POST** `https://voiceybill-server.vercel.app/api/auth/resend-otp` — Resend the verification OTP
+
+## Supported Methods
+
+- Email + password (email verified via OTP)
+- Password reset via `POST /api/auth/forgot-password` and `POST /api/auth/reset-password`
+
+## Credential Usage
+
+Authenticate to receive a JWT, then send it as a bearer token on every
+authenticated request.
+
+- **POST** `https://voiceybill-server.vercel.app/api/auth/login` — Authenticate and receive a JWT
 
 ### Request Format (Login)
 
@@ -36,9 +75,7 @@ Agents can register users via the signup endpoint or authenticate via Google OAu
 }
 ```
 
-## Using the Token
-
-Include the JWT in the `Authorization` header for all authenticated requests:
+### Using the Token
 
 ```
 Authorization: Bearer <token>
@@ -48,12 +85,7 @@ Authorization: Bearer <token>
 
 Tokens are valid for 7 days after issuance.
 
-## Supported Identity Types
-
-- Email/password
-- Google OAuth 2.0
-
 ## Rate Limits
 
-- Login: 5 attempts per minute per IP
-- Signup: 3 attempts per minute per IP
+- Login / register: 5 attempts per minute per IP
+- OTP endpoints: 3 attempts per minute per IP

--- a/public/webmcp.js
+++ b/public/webmcp.js
@@ -1,0 +1,131 @@
+/**
+ * VoiceyBill WebMCP tools.
+ *
+ * Exposes VoiceyBill's key in-page actions to AI agents through the WebMCP
+ * browser API (https://webmachinelearning.github.io/webmcp/). Tools are
+ * registered with `navigator.modelContext` when an agent-capable browser
+ * provides it. This runs entirely client-side and only navigates within the
+ * app that the signed-in user already has open — it never exposes credentials.
+ */
+(function () {
+  "use strict";
+
+  var ORIGIN = window.location.origin;
+
+  function go(path) {
+    window.location.assign(ORIGIN + path);
+    return { navigated_to: path };
+  }
+
+  var TOOLS = [
+    {
+      name: "voiceybill_open_section",
+      description:
+        "Navigate the VoiceyBill app to one of its main sections: overview, transactions, budget, reports, or settings.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          section: {
+            type: "string",
+            enum: ["overview", "transactions", "budget", "reports", "settings"],
+            description: "Which section to open.",
+          },
+        },
+        required: ["section"],
+      },
+      execute: async function (input) {
+        var args = (input && input.arguments) || input || {};
+        var map = {
+          overview: "/overview",
+          transactions: "/transactions",
+          budget: "/budget",
+          reports: "/reports",
+          settings: "/settings",
+        };
+        var path = map[args.section] || "/overview";
+        var result = go(path);
+        return {
+          content: [{ type: "text", text: "Opened " + args.section + " (" + path + ")." }],
+          structuredContent: result,
+        };
+      },
+    },
+    {
+      name: "voiceybill_add_transaction",
+      description:
+        "Open the VoiceyBill transactions page ready to add a new income or expense entry.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["income", "expense"],
+            description: "Whether to add income or an expense.",
+          },
+        },
+      },
+      execute: async function (input) {
+        var args = (input && input.arguments) || input || {};
+        var query = args.type ? "?add=true&type=" + encodeURIComponent(args.type) : "?add=true";
+        var result = go("/transactions" + query);
+        return {
+          content: [{ type: "text", text: "Opened the add-transaction view." }],
+          structuredContent: result,
+        };
+      },
+    },
+    {
+      name: "voiceybill_app_info",
+      description:
+        "Return a short description of VoiceyBill, its capabilities, and where an agent can authenticate.",
+      inputSchema: { type: "object", properties: {} },
+      execute: async function () {
+        var info = {
+          name: "VoiceyBill",
+          description:
+            "Personal financial platform: track income and expenses with voice input, AI receipt scanning, analytics, and scheduled reports.",
+          api: "https://voiceybill-server.vercel.app/api",
+          auth_doc: ORIGIN + "/auth.md",
+          mcp_server_card: ORIGIN + "/.well-known/mcp/server-card.json",
+        };
+        return {
+          content: [{ type: "text", text: JSON.stringify(info) }],
+          structuredContent: info,
+        };
+      },
+    },
+  ];
+
+  var registered = false;
+
+  function register() {
+    if (registered) return;
+    var mc = navigator.modelContext;
+    if (!mc) return;
+
+    // Preferred API: provideContext({ tools }).
+    if (typeof mc.provideContext === "function") {
+      mc.provideContext({ tools: TOOLS });
+      registered = true;
+      return;
+    }
+
+    // Fallback API: registerTool(tool) per tool.
+    if (typeof mc.registerTool === "function") {
+      TOOLS.forEach(function (tool) {
+        mc.registerTool(tool);
+      });
+      registered = true;
+    }
+  }
+
+  register();
+
+  // Some agent runtimes inject navigator.modelContext after initial scripts run.
+  if (!registered) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", register, { once: true });
+    }
+    window.addEventListener("load", register, { once: true });
+  }
+})();

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
       "headers": [
         {
           "key": "Link",
-          "value": "</.well-known/api-catalog>; rel=\"api-catalog\", </auth.md>; rel=\"service-doc\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\""
+          "value": "</.well-known/api-catalog>; rel=\"api-catalog\", </auth.md>; rel=\"service-doc\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\", </.well-known/oauth-authorization-server>; rel=\"oauth-authorization-server\", </.well-known/oauth-protected-resource>; rel=\"oauth-protected-resource\""
         }
       ]
     },
@@ -36,6 +36,32 @@
     {
       "source": "/.well-known/agent-skills/index.json",
       "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/oauth-authorization-server",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/oauth-protected-resource",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json"
+        },
         {
           "key": "Access-Control-Allow-Origin",
           "value": "*"


### PR DESCRIPTION
## What & why

Closes the remaining findings from [isitagentready.com/voiceybill.com](https://isitagentready.com/voiceybill.com) as part of the SEO / AI-discoverability effort.

## Changes

| Finding | Fix |
|---|---|
| No OAuth/OIDC discovery metadata | Add `/.well-known/oauth-authorization-server` (RFC 8414) — issuer, authorization/token/registration endpoints, `jwks_uri`, grant & response types, scopes, and an `agent_auth` block. |
| No OAuth Protected Resource Metadata | Add `/.well-known/oauth-protected-resource` (RFC 9728) — resource id, `authorization_servers`, `scopes_supported`. |
| `auth.md` missing the expected heading | Rewrite `public/auth.md` with the `# auth.md` H1, an `agent_auth` block, links to the OAuth metadata, and endpoints aligned to the real API (`/register`, `/login`, OTP verify). |
| No WebMCP tools detected | Add `public/webmcp.js` (loaded from `index.html`) registering tools via `navigator.modelContext.provideContext()` (with a `registerTool` fallback): open-section, add-transaction, app-info. |
| Site does not support Markdown for Agents | Add Vercel Edge Middleware (`middleware.ts`, `@vercel/edge`) so requests with `Accept: text/markdown` to public routes get a `text/markdown` response (with `x-markdown-tokens`); browsers still get HTML. |
| DNS-AID entrypoint records not found | Add `dns/dns-aid.zone` (SVCB/HTTPS records under `_agents`) + `docs/DNS-AID.md` runbook. **Requires publishing in Cloudflare + DNSSEC via Namecheap — see below.** |
| — | Wire the new well-known docs into the `vercel.json` `Link` header and set their `Content-Type`/CORS. |

## Action required outside this repo

**DNS-AID** is validated over DNS (no HTTP well-known fallback), so the records can't be served by the app. After merge, publish the records from `dns/dns-aid.zone` in **Cloudflare** and enable **DNSSEC** (DS record added at **Namecheap**). Full steps in [`docs/DNS-AID.md`](docs/DNS-AID.md).

## Verification

- `npm run build` (tsc + vite)
- `npm run lint` (0 errors; pre-existing warnings only)
- Confirmed `.well-known/oauth-*`, `auth.md`, and `webmcp.js` emit into `dist/`.
- The OAuth endpoints return 200 once this deploys to Vercel (production currently 307s because the files aren't live yet).